### PR TITLE
possible typo in variable description

### DIFF
--- a/code/chap02ex.ipynb
+++ b/code/chap02ex.ipynb
@@ -121,7 +121,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Make a histogram of <tt>parity</tt>, the number of people in the respondent's household.  How would you describe this distribution?"
+      "Make a histogram of <tt>parity</tt>, the total number of live births.  How would you describe this distribution?"
      ]
     },
     {


### PR DESCRIPTION
In the Chapter 2 exercises, `parity` is described as "the number of people in the respondent's household". Based on the [codebook description](http://www.icpsr.umich.edu/nsfg6/Controller?displayPage=labelDetails&fileCode=PREG&section=A&subSec=8018&srtLabel=611964), I believe it should be "the total number of live births".

Apologies if I'm overlooking something, and thanks for the exercises!