### PR TITLE
Fix example code

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -1189,7 +1189,7 @@ value	label                  Total
 And here are the value counts:
 
 \begin{verbatim}
->>> df.birthwgt_lb.value_counts(sort=False)
+>>> df.birthwgt_lb.value_counts().sort_index()
 0        8
 1       40
 2       53


### PR DESCRIPTION
> > > df.birthwgt_lb.value_counts(sort=False)
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > > TypeError: value_counts() got an unexpected keyword argument 'sort'

Accoring to the output, the author wanted to sort by index.
