### PR TITLE
Fix NameError when ValidatePregnum fails

### DIFF
--- a/code/chap01soln.py
+++ b/code/chap01soln.py
@@ -57,7 +57,7 @@ def ValidatePregnum(resp):
         # check that pregnum from the respondent file equals
         # the number of records in the pregnancy file
         if len(indices) != pregnum:
-            print(caseid, len(indices), resp.pregnum[index])
+            print(caseid, len(indices), pregnum)
             return False
 
     return True


### PR DESCRIPTION
The error handler was failing with NameError instead of returning False.
