### PR TITLE
Nicer iteraion over respondent file

### DIFF
--- a/code/chap01soln.py
+++ b/code/chap01soln.py
@@ -49,10 +49,10 @@ def ValidatePregnum(resp):
     # make the map from caseid to list of pregnancy indices
     preg_map = nsfg.MakePregMap(preg)
     
-    # iterate through the preg_map
-    for caseid, indices in preg_map.items():
-        row = resp[resp.caseid==caseid]
-        pregnum = row.pregnum.values[0]
+    # iterate through the respondent pregnum series
+    for index, pregnum in resp.pregnum.iteritems():
+        caseid = resp.caseid[index]
+        indices = preg_map[caseid]
 
         # check that pregnum from the respondent file equals
         # the number of records in the pregnancy file


### PR DESCRIPTION
The solution was iterating over the dictionary, getting the pregnum
value by matching resp.pregnum[caseid==caseid], which creates a boolean
array for all respondent and use it to filter pregnum values. This makes
sense when you want to get a single value, but not when you want to
iterated over all values.

Iterating over the pregnum series and accessing the caseid using the
index should be more efficient (I did not time it) and seems like a
better example code.
