### PR TITLE
Remove SettingWithCopyWarning from thinkstats2.py

### DIFF
--- a/code/thinkstats2.py
+++ b/code/thinkstats2.py
@@ -2618,7 +2618,7 @@ def ReadStataDct(dct_file, **options):
 
     # fill in the end column by shifting the start column
     variables['end'] = variables.start.shift(-1)
-    variables['end'][len(variables)-1] = 0
+    variables.loc[len(variables)-1, 'end'] = 0
 
     dct = FixedWidthVariables(variables, index_base=1)
     return dct


### PR DESCRIPTION
Fix SettingWithCopyWarning given by thinkstats2.py by using df.loc[b, a] rather than chain indexing df[a][b] as documented at:
http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy


