### PR TITLE
Updated to avoid 'PatsyError: model is missing required outcome variables'

### DIFF
--- a/code/regression.py
+++ b/code/regression.py
@@ -90,7 +90,7 @@ def GoMining(df):
             if df[name].var() < 1e-7:
                 continue
 
-            formula='totalwgt_lb ~ agepreg + ' + name
+            formula=('totalwgt_lb ~ agepreg + ' + name).encode('ascii')  # encode needed to avoid 'PatsyError: model is missing required outcome variables', per https://readditing.com/r/pystats/comments/2cn0go
             model = smf.ols(formula, data=df)
             if model.nobs < len(df)/2:
                 continue


### PR DESCRIPTION
As part of working through chapter 11, I hit an error w/ the following text: 'PatsyError: model is missing required outcome variables', from the GoMining function. I saw this error on both OS X and Windows. I was able to fix the error and get the expected output, on both platforms, by adding a call to 'encode', as shown in the commit associated with this pull request. (I found this idea at https://readditing.com/r/pystats/comments/2cn0go, which refers to this Patsy issue: https://github.com/pydata/patsy/issues/34.)

Two other things:
1. I'm really enjoying the book - thanks for writing it.
2. This is the first time I've submitted a pull request - I tried to follow instructions and it seems like it's worked as it should, but apologies in advance if I've done something incorrectly. If I can fix something to make it work, just let me know.