### PR TITLE
Make preg_map using MakePregMap() before using it.

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -1273,6 +1273,7 @@ for her pregnancies:
 
 \begin{verbatim}
 >>> caseid = 10229
+>>> preg_map = MakePregMap(df)
 >>> indices = preg_map[caseid]
 >>> df.outcome[indices].values
 [4 4 4 4 4 4 1]


### PR DESCRIPTION
In chapter 1, `preg_map` doesn't exist yet when it is used by `indices = preg_map[caseid]`. This commit adds a line to create `preg_map` using `MakePregMap()`.