### PR TITLE
ThinkStats2 variable clipped (Row 2629)

### DIFF
--- a/code/nsfg2.py
+++ b/code/nsfg2.py
@@ -67,9 +67,7 @@ def CleanFemPreg(df):
     # not attribute assignment (like df.totalwgt_lb)
     df['totalwgt_lb'] = df.birthwgt_lb1 + df.birthwgt_oz1 / 16.0    
 
-    # due to a bug in ReadStataDct, the last variable gets clipped;
-    # so for now set it to NaN
-    #df.phase = np.nan
+
 
 
 def main():

--- a/code/nsfg2.py
+++ b/code/nsfg2.py
@@ -69,7 +69,7 @@ def CleanFemPreg(df):
 
     # due to a bug in ReadStataDct, the last variable gets clipped;
     # so for now set it to NaN
-    df.phase = np.nan
+    #df.phase = np.nan
 
 
 def main():

--- a/code/thinkstats2.py
+++ b/code/thinkstats2.py
@@ -2626,7 +2626,7 @@ def ReadStataDct(dct_file, **options):
 
     # fill in the end column by shifting the start column
     variables['end'] = variables.start.shift(-1)
-    variables.loc[len(variables)-1, 'end'] = 0
+    variables.loc[len(variables)-1, 'end'] = variables.loc[len(variables)-1, 'start'] + int(variables.loc[len(variables)-1, 'fstring'][1:-1])
 
     dct = FixedWidthVariables(variables, index_base=1)
     return dct


### PR DESCRIPTION
When reading the fixed length ASCII file, as the end value is lower than the start value the column gets clipped. To solve this I propose to read the ‘fstring’ value to determine the amount of positions, and add this value to the start point. 

If this is solved, the note in the nsfg2 script (line 70) is no longer required.
