### PR TITLE
Add setup.py for thinkstats2 and thinkplot

### DIFF
--- a/code/setup.py
+++ b/code/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup
+
+
+setup(name='thinkstats2',
+      version='1.0',
+      description="Library code for Think Stats, 2nd Edition packaged",
+      author='Allen Downey',
+      license="GPLv3",
+      py_modules=['thinkstats2', 'thinkplot'],
+      url='https://github.com/AllenDowney/ThinkStats2',
+      install_requires=[
+          'matplotlib',
+          'numpy',
+          'pandas',
+          'scipy',
+          ],
+      )


### PR DESCRIPTION
This will allow you to conveniently publish `thinkstats2` and `thinkplot` modules on PyPI.  This way people can then just `pip install thinkstats2` and be able to import those two modules.

Thanks a bunch for a very nice book and useful library.  :-)