### PR TITLE
inconsistent naming of argument in description of Cdf.Percentile(p)

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -3104,7 +3104,7 @@ and percentile ranks.  The Cdf class provides these two methods:
 \item {\tt PercentileRank(x)}: Given a value {\tt x}, computes its
   percentile rank, $100 \cdot \CDF(x)$.
 
-\item {\tt Percentile(p)}: Given a percentile rank {\tt rank},
+\item {\tt Percentile(p)}: Given a percentile rank {\tt p},
   computes the corresponding value, {\tt x}.  Equivalent to {\tt
     Value(p/100)}.
 


### PR DESCRIPTION
In the description of the method Percentile of the class Cdf, the argument is twice called `p` and once called `rank`. I propose to consistently call it `p` in all instances.