### PR TITLE
Update numpy version to work with this version of pandas.

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib==1.4.3
 mock==1.0.1
 nose==1.3.6
-numpy==1.9.2
+numpy==1.11.1
 pandas==0.16.0
 pyparsing==2.0.3
 python-dateutil==2.4.2


### PR DESCRIPTION
On my MacOS 10.11.5 installation running python3, (not using anaconda), I got the following error:

```
$ virtualenv venv
$ source venv/bin/activate
$ python --version
$ python --version
Python 3.5.1
$ pip install -r requirements.txt
...
$ python nsfg.py 
numpy.dtype has the wrong size, try recompiling
```
After the included change:

```
$ virtualenv venv
$ source venv/bin/activate
$ pip install -r requirements.txt
...
$ python nsfg.py 
(13593, 244)
nsfg.py: All tests passed.
```

I haven't gotten to other examples from the book, so I'm not sure if anything else is broken. If so, I'll just switch to using anaconda instead.