### PR TITLE
Removed 'script' from the print statement

### DIFF
--- a/code/nsfg.py
+++ b/code/nsfg.py
@@ -157,8 +157,8 @@ def main():
     # of entries in `preg`
     assert(ValidatePregnum(resp, preg))
 
-
-    print('%s: All tests passed.' % script)
+    
+    print('All tests passed.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Following error is printed on running: 
`(13593, 244)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/home/ashish/Documents/ashish/ThinkStats2/code/nsfg.py in <module>()
     
     if __name__ == '__main__':
         main()

NameError: name 'script' is not defined
`

Fixed this error, by removing the script from print statement.