### PR TITLE
Fix a typo (remove an unnecessary `s`)

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -5249,7 +5249,7 @@ There are two common solutions to these problems:
 
 \begin{enumerate}
 
-\item Transform each value to a {\bf standard scores}, which is the
+\item Transform each value to a {\bf standard score}, which is the
 number of standard deviations from the mean.  
 This transform leads to
 the ``Pearson product-moment correlation coefficient.''


### PR DESCRIPTION
In the section on correlation:

`Transform each value to a {\bf standard scores}` -> `Transform each value to a {\bf standard score}` ->