### PR TITLE
#79 Using the iteritems() method for grabbing the data from a Series …

### DIFF
--- a/code/thinkstats2.py
+++ b/code/thinkstats2.py
@@ -152,7 +152,7 @@ class _DictWrapper(object):
         elif isinstance(obj, (_DictWrapper, Cdf, Pdf)):
             self.d.update(obj.Items())
         elif isinstance(obj, pandas.Series):
-            self.d.update(obj.value_counts().items())
+            self.d.update(obj.value_counts().iteritems())
         else:
             # finally, treat it like a list
             self.d.update(Counter(obj))


### PR DESCRIPTION
…when updating data in a _DictWrapper class. The pandas 0.20.3 release for Python 2.7 does not have an items() method while the release Python 3.7 does, and both versions have iteritems() which provides the data in the proper format.

The chap03ex notebook works with this code in Py27 and Py36. The thinkstats2_test module passes in both Py27 and Py36.

```
Mike:code gbremer$ python -V
Python 2.7.13 :: Continuum Analytics, Inc.
Mike:code gbremer$ python thinkstats2_test.py
..[ 0.16666667  0.33333333  0.66666667  0.66666667  0.83333333  1.        ]
........................
----------------------------------------------------------------------
Ran 26 tests in 0.303s

OK
```

```
Python 3.6.2 :: Continuum Analytics, Inc.
Mike:code gbremer$ python thinkstats2_test.py
..[ 0.16666667  0.33333333  0.66666667  0.66666667  0.83333333  1.        ]
.................../Users/gbremer/projects/ThinkStats2/code/thinkstats2.py:2646: ResourceWarning: unclosed file <_io.TextIOWrapper name='2002FemPreg.dct' mode='r' encoding='UTF-8'>
  for line in open(dct_file, **options):
.....
----------------------------------------------------------------------
Ran 26 tests in 0.221s

OK
```