### PR TITLE
#85 Using items() instead of iteritems() when looping over a dict for…

### DIFF
--- a/code/pandas_demos.ipynb
+++ b/code/pandas_demos.ipynb
@@ -747,7 +747,7 @@
      "input": [
       "import numpy\n",
       "\n",
-      "for sex, weights in d.iteritems():\n",
+      "for sex, weights in d.items():\n",
       "    print(sex, numpy.log(weights).mean(), numpy.log(weights).std())"
      ],
      "language": "python",


### PR DESCRIPTION
… Python 3 compatibility

Notebook works in Python 2.7 and Python 3.6.