### PR TITLE
Fix link to issues tab

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Contributing is so kind of you. In ThinkStats2, all contributions, bug reports, bug
 fixes, documentation improvements, enhancements and ideas are welcome.
 
-The [GitHub "issues" tab](https://github.com/AllenDowning/ThinkStats2/issues)
+The [GitHub "issues" tab](https://github.com/AllenDowney/ThinkStats2/issues)
 contains some issues labeled "first PR". Those are open issues that would be a
 good quick way to get started. Browse them to see if you want to get started on
 one.


### PR DESCRIPTION
Fix the link in CONTRIBUTING.md to the Github issues tab.