### PR TITLE
Use first_cdf instead of cdf for first-born percentile rank

### DIFF
--- a/code/chap04soln.ipynb
+++ b/code/chap04soln.ipynb
@@ -721,7 +721,7 @@
     {
      "data": {
       "text/plain": [
-       "0.021862702229995628"
+       "85.904194361677739"
       ]
      },
      "execution_count": 26,
@@ -732,7 +732,7 @@
    "source": [
     "# Solution\n",
     "\n",
-    "cdf.PercentileRank(8.5)"
+    "first_cdf.PercentileRank(8.5)"
    ]
   },
   {


### PR DESCRIPTION
It appears that the incorrect `cdf` was chosen for the `first` dataset. 