### PR TITLE
Add 'activate' note for conda versions from 4.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,13 @@ Activate the 2.7 environment and install nose and lifelines
  - source activate thinkstats2-py27
  - pip install nose lifelines
 
-Activate the 3.6 environment and install nose
+Activate the 3.6 environment and install nose and lifelines
 
  - source activate thinkstats2-py36
  - pip install nose lifelines
+
+*For conda versions after 4.4 use `conda activate` instead of `source activate`*
+
 
 Extras that are helpful --
 


### PR DESCRIPTION
The `conda activate` command  has been the preferred since version 4.4 (released around December 2017). In short, the old `source activate` command does not work reliably in all environments and may not even be available in newer installations. The new `conda activate` command resolves those issues.

The note is a minimal change to help with this. You may want to consider inverting this at some point: making `conda activate` the main instruction and adding a not about versions earlier than 4.4.