### PR TITLE
Fix test of str representation of new Cdf object

### DIFF
--- a/code/thinkstats2_test.py
+++ b/code/thinkstats2_test.py
@@ -199,7 +199,7 @@ class Test(unittest.TestCase):
         hist = thinkstats2.Hist(t)
 
         cdf = thinkstats2.Cdf(pmf)
-        self.assertEqual(len(str(cdf)), 37)
+        self.assertEqual(len(str(cdf)), 33)
 
         self.assertEqual(cdf[0], 0)
         self.assertAlmostEqual(cdf[1], 0.2)


### PR DESCRIPTION
This is now 4 characters shorter than previously expected. I'm guessing
that this is because the first numpy array may have changed from
"[1, 2, 3, 5]" to "[1., 2., 3., 5.,]".