### PR TITLE
Use a clean sans-serif font for pdfs

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -15,8 +15,9 @@
 
 % for some of these packages, you might have to install
 % texlive-latex-extra (in Ubuntu)
+% texlive-collection-fontsrecommended (in Fedora)
 
-%\usepackage[T1]{fontenc}
+\usepackage[T1]{fontenc}
 %\usepackage{textcomp}
 %\usepackage{mathpazo}
 %\usepackage{pslatex}
@@ -33,6 +34,10 @@
 \usepackage{setspace}
 \usepackage{hevea}                           
 \usepackage{upquote}
+
+% use a modern sans-serif font for PDFs read on a computer
+\usepackage{lmodern}
+\renewcommand{\familydefault}{\sfdefault}
 
 \title{Think Stats}
 \author{Allen B. Downey}


### PR DESCRIPTION
Serif fonts look great when printed, but can be quite difficult to read on modern displays. I found this to be a definite blocker to reading the book on both my laptop and an attached display, so I figured out an almost minimal change to get an sans-serif font that scales well.  You may want to adapt this PR to offer an alternative PDFs to you readers.