### PR TITLE
Fix variable name for pregnancy order

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -862,7 +862,7 @@ infile dictionary {
 \end{verbatim}
 
 This dictionary describes two variables: {\tt caseid} is a 12-character
-string that represents the respondent ID; {\tt pregorder} is a 
+string that represents the respondent ID; {\tt pregordr} is a 
 one-byte integer that indicates which pregnancy this record
 describes for this respondent.
 


### PR DESCRIPTION
The variable name for pregnancy order should be `pregordr`, not `pregorder`.