### PR TITLE
Replace tabs with spaces in verbatim environments

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -1089,9 +1089,9 @@ baby, in pounds and ounces, for pregnancies that end in live birth.
 In addition it uses several special codes:
 
 \begin{verbatim}
-97	NOT ASCERTAINED
-98	REFUSED	 
-99	DON'T KNOW
+97      NOT ASCERTAINED
+98      REFUSED
+99      DON'T KNOW
 \end{verbatim}
 
 Special values encoded as numbers are {\em dangerous} because if they
@@ -1155,13 +1155,13 @@ tables that summarize each variable.  Here is the table for
 {\tt outcome}, which encodes the outcome of each pregnancy:
 
 \begin{verbatim}
-value	label	 	        Total
-1	LIVE BIRTH              9148
-2	INDUCED ABORTION        1862
-3	STILLBIRTH               120
-4	MISCARRIAGE             1921
-5	ECTOPIC PREGNANCY        190
-6	CURRENT PREGNANCY        352
+value   label                  Total
+1       LIVE BIRTH              9148
+2       INDUCED ABORTION        1862
+3       STILLBIRTH               120
+4       MISCARRIAGE             1921
+5       ECTOPIC PREGNANCY        190
+6       CURRENT PREGNANCY        352
 \end{verbatim}
 
 The Series class provides a method, \verb"value_counts", that
@@ -1190,13 +1190,13 @@ values in {\tt outcome} are correct.  Similarly, here is the published
 table for \verb"birthwgt_lb"
 
 \begin{verbatim}
-value	label                  Total
-.	INAPPLICABLE            4449
-0-5	UNDER 6 POUNDS          1125
-6	6 POUNDS                2223
-7	7 POUNDS                3049
-8	8 POUNDS                1889
-9-95	9 POUNDS OR MORE         799
+value   label                  Total
+.       INAPPLICABLE            4449
+0-5     UNDER 6 POUNDS          1125
+6       6 POUNDS                2223
+7       7 POUNDS                3049
+8       8 POUNDS                1889
+9-95    9 POUNDS OR MORE         799
 \end{verbatim}
 
 And here are the value counts:


### PR DESCRIPTION
This fixes the layout of 3 blocks in the 'Exploratory data analysis'
chapter.