### PR TITLE
Fix indexing and crossref errors

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -261,7 +261,7 @@ Unported License, which is available at
 \fi
 % END OF THE PART WE SKIP FOR PLASTEX
 
-\chapter{Preface}
+\chapter{Preface}%
 \label{preface}
 
 This book is an
@@ -274,45 +274,45 @@ when I start working with a dataset:
 \item Importing and cleaning: Whatever format the data is in, it
   usually takes some time and effort to read the data, clean and
   transform it, and check that everything made it through the
-  translation process intact.
+  translation process intact.%
 \index{cleaning}
 
 \item Single variable explorations: I usually start by examining one
   variable at a time, finding out what the variables mean, looking
   at distributions of the values, and choosing appropriate
-  summary statistics.
+  summary statistics.%
 \index{distribution}
 
 \item Pair-wise explorations: To identify possible relationships
   between variables, I look at tables and scatter plots, and compute
-  correlations and linear fits.
-\index{correlation}
+  correlations and linear fits.%
+\index{correlation}%
 \index{linear fit}
 
 \item Multivariate analysis: If there are apparent relationships
   between variables, I use multiple regression to add control variables
-  and investigate more complex relationships.
-\index{multiple regression}
+  and investigate more complex relationships.%
+\index{multiple regression}%
 \index{control variable}
 
 \item Estimation and hypothesis testing: When reporting statistical
   results, it is important to answer three questions: How big is
   the effect?  How much variability should we expect if we run the same
   measurement again?  Is it possible that the apparent effect is
-  due to chance?
-\index{estimation}
+  due to chance?%
+\index{estimation}%
 \index{hypothesis testing}
 
 \item Visualization: During exploration, visualization is an important 
   tool for finding possible relationships and effects.  Then if an
   apparent effect holds up to scrutiny, visualization is an effective
-  way to communicate results.
+  way to communicate results.%
 \index{visualization}
 
 \end{itemize}
 
 This book takes a computational approach, which has several
-advantages over mathematical approaches:
+advantages over mathematical approaches:%
 \index{computational methods}
 
 \begin{itemize}
@@ -325,21 +325,21 @@ advantages over mathematical approaches:
 \item Each chapter includes exercises readers can do to develop
   and solidify their learning.  When you write programs, you
   express your understanding in code; while you are debugging the
-  program, you are also correcting your understanding.
+  program, you are also correcting your understanding.%
 \index{debugging}
 
 \item Some exercises involve experiments to test statistical
   behavior.  For example, you can explore the Central Limit Theorem
   (CLT) by generating random samples and computing their sums.  The
   resulting visualizations demonstrate why the CLT works and when
-  it doesn't.
-\index{Central Limit Theorem}
+  it doesn't.%
+\index{Central Limit Theorem}%
 \index{CLT}
 
 \item Some ideas that are hard to grasp mathematically are easy to
   understand by simulation.  For example, we approximate p-values by
   running random simulations, which reinforces the meaning of the
-  p-value.
+  p-value.%
 \index{p-value}
 
 \item Because the book is based on a general-purpose programming
@@ -424,7 +424,7 @@ Other resources I found useful were Wolfram MathWorld and
 the Reddit statistics forum, \url{http://www.reddit.com/r/statistics}.
 
 
-\section{Using the code}
+\section{Using the code}%
 \label{code}
 
 The code and data used in this book are available from
@@ -432,9 +432,9 @@ The code and data used in this book are available from
 control system that allows you to keep track of the files that
 make up a project.  A collection of files under Git's control is
 called a {\bf repository}.  GitHub is a hosting service that provides
-storage for Git repositories and a convenient web interface.
-\index{repository}
-\index{Git}
+storage for Git repositories and a convenient web interface.%
+\index{repository}%
+\index{Git}%
 \index{GitHub}
 
 The GitHub homepage for my repository provides several ways to
@@ -448,12 +448,12 @@ have a GitHub account, you'll need to create one.  After forking, you'll
 have your own repository on GitHub that you can use to keep track
 of code you write while working on this book.  Then you can
 clone the repo, which means that you make a copy of the files
-on your computer.
+on your computer.%
 \index{fork}
 
 \item Or you could clone
 my repository.  You don't need a GitHub account to do this, but you
-won't be able to write your changes back to GitHub.
+won't be able to write your changes back to GitHub.%
 \index{clone}
 
 \item If you don't want to use Git at all, you can download the files
@@ -471,7 +471,7 @@ all the packages you'll need to run the code (and lots more).
 I found Anaconda easy to install.  By default it does a user-level
 installation, not system-level, so you don't need administrative
 privileges.  And it supports both Python 2 and Python 3.  You can
-download Anaconda from \url{http://continuum.io/downloads}.
+download Anaconda from \url{http://continuum.io/downloads}.%
 \index{Anaconda}
 
 If you don't want to use Anaconda, you will need the following
@@ -480,21 +480,21 @@ packages:
 \begin{itemize}
 
 \item pandas for representing and analyzing data,
-  \url{http://pandas.pydata.org/};
+  \url{http://pandas.pydata.org/};%
 \index{pandas}
 
-\item NumPy for basic numerical computation, \url{http://www.numpy.org/};
+\item NumPy for basic numerical computation, \url{http://www.numpy.org/};%
 \index{NumPy}
 
 \item SciPy for scientific computation including statistics,
-  \url{http://www.scipy.org/};
+  \url{http://www.scipy.org/};%
 \index{SciPy}
 
 \item StatsModels for regression and other statistical analysis,
-\url{http://statsmodels.sourceforge.net/}; and
+\url{http://statsmodels.sourceforge.net/}; and%
 \index{StatsModels}
 
-\item matplotlib for visualization, \url{http://matplotlib.org/}.
+\item matplotlib for visualization, \url{http://matplotlib.org/}.%
 \index{matplotlib}
 
 \end{itemize}
@@ -503,7 +503,7 @@ Although these are commonly used packages, they are not included with
 all Python installations, and they can be hard to install in some
 environments.  If you have trouble installing them, I strongly
 recommend using Anaconda or one of the other Python distributions
-that include these packages.
+that include these packages.%
 \index{installation}
 
 After you clone the repository or unzip the zip file, you should have
@@ -515,7 +515,7 @@ probably means there are packages you need to install.
 Most exercises use Python scripts, but some also use the IPython
 notebook.  If you have not used IPython notebook before, I suggest
 you start with the documentation at
-\url{http://ipython.org/ipython-doc/stable/notebook/notebook.html}.
+\url{http://ipython.org/ipython-doc/stable/notebook/notebook.html}.%
 \index{IPython}
 
 I wrote this book assuming that the reader is familiar with core Python,
@@ -547,7 +547,7 @@ the Franklin W. Olin College of Engineering in Needham, MA.
 If you have a suggestion or correction, please send email to 
 {\tt downey@allendowney.com}.  If I make a change based on your
 feedback, I will add you to the contributor list
-(unless you ask to be omitted).
+(unless you ask to be omitted).%
 \index{contributors}
 
 If you include at least part of the sentence the
@@ -655,7 +655,7 @@ Luigi Patruno.
 \mainmatter
 
 
-\chapter{Exploratory data analysis}
+\chapter{Exploratory data analysis}%
 \label{intro}
 
 The thesis of this book is that data combined with practical
@@ -663,7 +663,7 @@ methods can answer questions and guide decisions under uncertainty.
 
 As an example, I present a case study motivated by a question
 I heard when my wife and I were expecting our first child: do first
-babies tend to arrive late?
+babies tend to arrive late?%
 \index{first babies}
 
 If you Google this question, you will find plenty of discussion.  Some
@@ -690,7 +690,7 @@ first and she was early, as with many of my cousins.''
 Reports like these are called {\bf anecdotal evidence} because they
 are based on data that is unpublished and usually personal.  In casual
 conversation, there is nothing wrong with anecdotes, so I don't mean
-to pick on the people I quoted.
+to pick on the people I quoted.%
 \index{anecdotal evidence}
 
 But we might want evidence that is more persuasive and
@@ -702,19 +702,19 @@ evidence usually fails, because:
 \item Small number of observations: If pregnancy length is longer
   for first babies, the difference is probably small compared to
   natural variation.  In that case, we might have to compare a large
-  number of pregnancies to be sure that a difference exists.
+  number of pregnancies to be sure that a difference exists.%
 \index{pregnancy length}
 
 \item Selection bias: People who join a discussion of this question
   might be interested because their first babies were late.  In that
-  case the process of selecting data would bias the results.
-\index{selection bias}
+  case the process of selecting data would bias the results.%
+\index{selection bias}%
 \index{bias!selection}
 
 \item Confirmation bias:  People who believe the claim might be more
   likely to contribute examples that confirm it.  People who doubt the
-  claim are more likely to cite counterexamples.
-\index{confirmation bias}
+  claim are more likely to cite counterexamples.%
+\index{confirmation bias}%
 \index{bias!confirmation}
 
 \item Inaccuracy: Anecdotes are often personal stories, and often
@@ -735,27 +735,27 @@ of statistics, which include:
 
 \item Data collection: We will use data from a large national survey
   that was designed explicitly with the goal of generating
-  statistically valid inferences about the U.S. population.
+  statistically valid inferences about the U.S. population.%
 \index{data collection}
 
 \item Descriptive statistics: We will generate statistics that
   summarize the data concisely, and evaluate different ways to
-  visualize data.
+  visualize data.%
 \index{descriptive statistics}
 
 \item Exploratory data analysis: We will look for
   patterns, differences, and other features that address the questions
   we are interested in.  At the same time we will check for
-  inconsistencies and identify limitations.
+  inconsistencies and identify limitations.%
 \index{exploratory data analysis}
 
 \item Estimation: We will use data from a sample to estimate
-  characteristics of the general population.
+  characteristics of the general population.%
 \index{estimation}
 
 \item Hypothesis testing: Where we see apparent effects, like a
   difference between two groups, we will evaluate whether the effect
-  might have happened by chance.
+  might have happened by chance.%
 \index{hypothesis testing}
 
 \end{itemize}
@@ -765,7 +765,7 @@ reach conclusions that are more justifiable and more likely to be
 correct.
 
 
-\section{The National Survey of Family Growth}
+\section{The National Survey of Family Growth}%
 \label{nsfg}
 
 Since 1973 the U.S. Centers for Disease Control and Prevention (CDC)
@@ -775,8 +775,8 @@ divorce, pregnancy, infertility, use of contraception, and men's and
 women's health. The survey results are used ... to plan health services and
 health education programs, and to do statistical studies of families,
 fertility, and health.''  See
-  \url{http://cdc.gov/nchs/nsfg.htm}.
-\index{National Survey of Family Growth}
+  \url{http://cdc.gov/nchs/nsfg.htm}.%
+\index{National Survey of Family Growth}%
 \index{NSFG}
 
 We will use data collected by this survey to investigate whether first
@@ -786,37 +786,39 @@ data effectively, we have to understand the design of the study.
 The NSFG is a {\bf cross-sectional} study, which means that it
 captures a snapshot of a group at a point in time.  The most
 common alternative is a {\bf longitudinal} study, which observes a
-group repeatedly over a period of time.
-\index{cross-sectional study}
-\index{study!cross-sectional}
-\index{longitudinal study}
+group repeatedly over a period of time.%
+\index{cross-sectional study}%
+\index{study!cross-sectional}%
+\index{longitudinal study}%
 \index{study!longitudinal}
 
 The NSFG has been conducted seven times; each deployment is called a
 {\bf cycle}.  We will use data from Cycle 6, which was conducted from
-January 2002 to March 2003.  \index{cycle}
+January 2002 to March 2003.%
+\index{cycle}
 
 The goal of the survey is to draw conclusions about a {\bf
   population}; the target population of the NSFG is people in the
 United States aged 15-44.  Ideally surveys would collect data from
 every member of the population, but that's seldom possible.  Instead
 we collect data from a subset of the population called a {\bf sample}.
-The people who participate in a survey are called {\bf respondents}.
+The people who participate in a survey are called {\bf respondents}.%
 \index{population}
 
 In general,
 cross-sectional studies are meant to be {\bf representative}, which
 means that every member of the target population has an equal chance
 of participating.  That ideal is hard to achieve in
-practice, but people who conduct surveys come as close as they can.
-\index{respondent} \index{representative}
+practice, but people who conduct surveys come as close as they can.%
+\index{respondent}%
+\index{representative}
 
 The NSFG is not representative; instead it is deliberately {\bf
   oversampled}.  The designers of the study recruited three
 groups---Hispanics, African-Americans and teenagers---at rates higher
 than their representation in the U.S. population, in order to
 make sure that the number of respondents in each of
-these groups is large enough to draw valid statistical inferences.
+these groups is large enough to draw valid statistical inferences.%
 \index{oversampling}
 
 Of course, the drawback of oversampling is that it is not as easy
@@ -887,7 +889,7 @@ information from the dictionary file.  {\tt dct} provides {\tt
   ReadFixedWidth}, which reads the data file.
 
 
-\section{DataFrames}
+\section{DataFrames}%
 \label{dataframe}
 
 The result of {\tt ReadFixedWidth} is a DataFrame, which is the
@@ -895,8 +897,8 @@ fundamental data structure provided by pandas, which is a Python
 data and statistics package we'll use throughout this book.
 A DataFrame contains a
 row for each record, in this case one row per pregnancy, and a column
-for each variable.
-\index{pandas}
+for each variable.%
+\index{pandas}%
 \index{DataFrame}
 
 In addition to the data, a DataFrame also contains the variable
@@ -928,8 +930,8 @@ Index([u'caseid', u'pregordr', u'howpreg_n', u'howpreg_p', ... ])
 
 The result is an Index, which is another pandas data structure.  
 We'll learn more about Index later, but for
-now we'll treat it like a list:
-\index{pandas}
+now we'll treat it like a list:%
+\index{pandas}%
 \index{Index}
 
 \begin{verbatim}
@@ -938,7 +940,7 @@ now we'll treat it like a list:
 \end{verbatim}
 
 To access a column from a DataFrame, you can use the column
-name as a key:
+name as a key:%
 \index{DataFrame}
 
 \begin{verbatim}
@@ -950,7 +952,7 @@ name as a key:
 The result is a Series, yet another pandas data structure.
 A Series is like a Python list with some additional features.
 When you print a Series, you get the indices and the
-corresponding values:
+corresponding values:%
 \index{Series}
 
 \begin{verbatim}
@@ -972,7 +974,7 @@ are also integers, but they can be any type.
 
 The last line includes the variable name, Series length, and data type;
 {\tt int64} is one of the types provided by NumPy.  If you run
-this example on a 32-bit machine you might see {\tt int32}.
+this example on a 32-bit machine you might see {\tt int32}.%
 \index{NumPy}
 
 You can access the elements of a Series using integer indices
@@ -991,7 +993,7 @@ Name: pregordr, dtype: int64
 The result of the index operator is an {\tt int64}; the
 result of the slice is another Series.
 
-You can also access the columns of a DataFrame using dot notation:
+You can also access the columns of a DataFrame using dot notation:%
 \index{DataFrame}
 
 \begin{verbatim}
@@ -1013,7 +1015,7 @@ variables:
 
 \item {\tt caseid} is the integer ID of the respondent.
 
-\item {\tt prglngth} is the integer duration of the pregnancy in weeks.
+\item {\tt prglngth} is the integer duration of the pregnancy in weeks.%
 \index{pregnancy length}
 
 \item {\tt outcome} is an integer code for the outcome of the
@@ -1028,23 +1030,25 @@ variables:
   For outcomes other than live birth, this field is blank.
 
 \item \verb"birthwgt_lb" and \verb"birthwgt_oz" contain the pounds and
-  ounces parts of the birth weight of the baby.
-\index{birth weight}
+  ounces parts of the birth weight of the baby.%
+\index{birth weight}%
 \index{weight!birth}
 
 \item {\tt agepreg} is the mother's age at the end of the pregnancy.
 
 \item {\tt finalwgt} is the statistical weight associated with the
   respondent.  It is a floating-point value that indicates the number
-  of people in the U.S. population this respondent represents.
-  \index{weight!sample}
+  of people in the U.S. population this respondent represents.%
+\index{weight!sample}
 
 \end{itemize}
 
 If you read the codebook carefully, you will see that many of the
 variables are {\bf recodes}, which means that they are not part of the
 {\bf raw data} collected by the survey; they are calculated using
-the raw data.  \index{recode} \index{raw data}
+the raw data.%
+\index{recode}%
+\index{raw data}
 
 For example, {\tt prglngth} for live births is equal to the raw
 variable {\tt wksgest} (weeks of gestation) if it is available;
@@ -1057,7 +1061,7 @@ when they are available, unless there is a compelling reason to
 process the raw data yourself.
 
 
-\section{Transformation}
+\section{Transformation}%
 \label{cleaning}
 
 When you import data like this, you often have to check for errors,
@@ -1099,7 +1103,7 @@ are not handled properly, they can generate bogus results, like
 a 99-pound baby.  The {\tt replace} method replaces these values with
 {\tt np.nan}, a special floating-point value that represents ``not a
 number.''  The {\tt inplace} flag tells {\tt replace} to modify the
-existing Series rather than create a new one.
+existing Series rather than create a new one.%
 \index{NaN}
 
 As part of the IEEE floating-point standard, all mathematical
@@ -1113,8 +1117,8 @@ nan
 
 So computations with {\tt nan} tend to do the right thing, and most
 pandas functions handle {\tt nan} appropriately.  But dealing with
-missing data will be a recurring issue.
-\index{pandas}
+missing data will be a recurring issue.%
+\index{pandas}%
 \index{missing values}
 
 The last line of {\tt CleanFemPreg} creates a new
@@ -1122,7 +1126,7 @@ column \verb"totalwgt_lb" that combines pounds and ounces into
 a single quantity, in pounds.
 
 One important note: when you add a new column to a DataFrame, you
-must use dictionary syntax, like this
+must use dictionary syntax, like this%
 \index{DataFrame}
 
 \begin{verbatim}
@@ -1167,8 +1171,8 @@ value   label                  Total
 The Series class provides a method, \verb"value_counts", that
 counts the number of times each value appears.  If we select the {\tt
   outcome} Series from the DataFrame, we can use \verb"value_counts"
-to compare with the published data:
-\index{DataFrame}
+to compare with the published data:%
+\index{DataFrame}%
 \index{Series}
 
 \begin{verbatim}
@@ -1237,16 +1241,17 @@ This statement replaces invalid values with {\tt np.nan}.
 The attribute {\tt loc} provides several ways to select
 rows and columns from a DataFrame.  In this example, the
 first expression in brackets is the row indexer; the second
-expression selects the column.
-\index{loc indexer}
+expression selects the column.%
+\index{loc indexer}%
 \index{indexer!loc}
 
 The expression \verb"df.birthwgt_lb > 20" yields a Series of type
 {\tt bool}, where True indicates that the condition is true.  When a
 boolean Series is used as an index, it selects only the elements that
-satisfy the condition.
-\index{Series} \index{boolean} \index{NaN}
-
+satisfy the condition.%
+\index{Series}%
+\index{boolean}%
+\index{NaN}
 
 
 \section{Interpretation}
@@ -1269,7 +1274,7 @@ def MakePregMap(df):
 
 {\tt df} is the DataFrame with pregnancy data.  The {\tt iteritems}
 method enumerates the index (row number)
-and {\tt caseid} for each pregnancy.
+and {\tt caseid} for each pregnancy.%
 \index{DataFrame}
 
 {\tt d} is a dictionary that maps from each case ID to a list of
@@ -1295,8 +1300,8 @@ to respondent {\tt 10229}.
 Using this list as an index into {\tt df.outcome} selects the
 indicated rows and yields a Series.  Instead of printing the
 whole Series, I selected the {\tt values} attribute, which is
-a NumPy array.  
-\index{NumPy}
+a NumPy array.%
+\index{NumPy}%
 \index{Series}
 
 The outcome code {\tt 1} indicates a live birth. Code {\tt 4} indicates
@@ -1316,7 +1321,7 @@ honest answers to many personal and difficult questions.  We can use
 this data to answer statistical questions about family life,
 reproduction, and health.  At the same time, we have an obligation
 to consider the people represented by the data, and to afford them
-respect and gratitude.
+respect and gratitude.%
 \index{ethics}
 
 
@@ -1325,7 +1330,7 @@ respect and gratitude.
 \begin{exercise}
 In the repository you downloaded, you should find a file named
 \verb"chap01ex.ipynb", which is an IPython notebook.  You can
-launch IPython notebook from the command line like this:
+launch IPython notebook from the command line like this:%
 \index{IPython}
 
 \begin{verbatim}
@@ -1372,7 +1377,7 @@ records in the pregnancy file.
 
 You can use {\tt nsfg.MakePregMap} to make a dictionary that maps
 from each {\tt caseid} to a list of indices into the pregnancy
-DataFrame.
+DataFrame.%
 \index{DataFrame}
 
 A solution to this exercise is in \verb"chap01soln.py"
@@ -1419,53 +1424,53 @@ the data, or agree to certain terms of use.  Be persistent!
 \begin{itemize}
 
 \item {\bf anecdotal evidence}: Evidence, often personal, that is collected
-  casually rather than by a well-designed study.
+  casually rather than by a well-designed study.%
 \index{anecdotal evidence}
 
 \item {\bf population}: A group we are interested in studying.
   ``Population'' often refers to a
   group of people, but the term is used for other subjects,
-  too.
+  too.%
 \index{population}
 
 \item {\bf cross-sectional study}: A study that collects data about a
-population at a particular point in time.
-\index{cross-sectional study}
+population at a particular point in time.%
+\index{cross-sectional study}%
 \index{study!cross-sectional}
 
 \item {\bf cycle}: In a repeated cross-sectional study, each repetition
 of the study is called a cycle.
 
 \item {\bf longitudinal study}: A study that follows a population over
-time, collecting data from the same group repeatedly.
-\index{longitudinal study}
+time, collecting data from the same group repeatedly.%
+\index{longitudinal study}%
 \index{study!longitudinal}
 
 \item {\bf record}: In a dataset, a collection of information about
-a single person or other subject.
+a single person or other subject.%
 \index{record}
 
-\item {\bf respondent}: A person who responds to a survey.
+\item {\bf respondent}: A person who responds to a survey.%
 \index{respondent}
 
-\item {\bf sample}: The subset of a population used to collect data.
+\item {\bf sample}: The subset of a population used to collect data.%
 \index{sample}
 
 \item {\bf representative}: A sample is representative if every member
-of the population has the same chance of being in the sample.
+of the population has the same chance of being in the sample.%
 \index{representative}
 
 \item {\bf oversampling}: The technique of increasing the representation
 of a sub-population in order to avoid errors due to small sample
-sizes.
+sizes.%
 \index{oversampling}
 
 \item {\bf raw data}: Values collected and recorded with little or no
-checking, calculation or interpretation.
+checking, calculation or interpretation.%
 \index{raw data}
 
 \item {\bf recode}: A value that is generated by calculation and other
-logic applied to raw data.
+logic applied to raw data.%
 \index{recode}
 
 \item {\bf data cleaning}: Processes that include validating data,
@@ -1476,22 +1481,24 @@ logic applied to raw data.
 
 
 
-\chapter{Distributions}
+\chapter{Distributions}%
 \label{descriptive}
 
 
-\section{Histograms}
+\section{Histograms}%
 \label{histograms}
 
 One of the best ways to describe a variable is to report the values
 that appear in the dataset and how many times each value appears.
-This description is called the {\bf distribution} of the variable.
+This description is called the {\bf distribution} of the variable.%
 \index{distribution}
 
 The most common representation of a distribution is a {\bf histogram},
 which is a graph that shows the {\bf frequency} of each value.  In
 this context, ``frequency'' means the number of times the value
-appears.  \index{histogram} \index{frequency}
+appears.%
+\index{histogram}%
+\index{frequency}%
 \index{dictionary}
 
 In Python, an efficient way to compute frequencies is with a
@@ -1518,12 +1525,12 @@ dictionary.
 Another option is to use the pandas method \verb"value_counts", which
 we saw in the previous chapter.  But for this book I created a class,
 Hist, that represents histograms and provides the methods
-that operate on them.
+that operate on them.%
 \index{pandas}
 
 
-\section{Representing histograms}
-\index{histogram}
+\section{Representing histograms}%
+\index{histogram}%
 \index{Hist}
 
 The Hist constructor can take a sequence, dictionary, pandas
@@ -1537,14 +1544,16 @@ Hist({1: 1, 2: 2, 3: 1, 5: 1})
 \end{verbatim}
 
 Hist objects provide {\tt Freq}, which takes a value and
-returns its frequency: \index{frequency}
+returns its frequency:%
+\index{frequency}
 %
 \begin{verbatim}
 >>> hist.Freq(2)
 2
 \end{verbatim}
 
-The bracket operator does the same thing: \index{bracket operator}
+The bracket operator does the same thing:%
+\index{bracket operator}
 %
 \begin{verbatim}
 >>> hist[2]
@@ -1574,7 +1583,8 @@ for val in sorted(hist.Values()):
 \end{verbatim}
 
 Or you can use {\tt Items} to iterate through
-value-frequency pairs: \index{frequency}
+value-frequency pairs:%
+\index{frequency}
 %
 \begin{verbatim}
 for val, freq in hist.Items():
@@ -1582,13 +1592,13 @@ for val, freq in hist.Items():
 \end{verbatim}
 
 
-\section{Plotting histograms}
+\section{Plotting histograms}%
 \index{pyplot}
 
 \begin{figure}
 % first.py
 \centerline{\includegraphics[height=2.5in]{figs/first_wgt_lb_hist.pdf}}
-\caption{Histogram of the pound part of birth weight.}
+\caption{Histogram of the pound part of birth weight.}%
 \label{first_wgt_lb_hist}
 \end{figure}
 
@@ -1596,10 +1606,11 @@ For this book I wrote a module called {\tt thinkplot.py} that provides
 functions for plotting Hists and other objects defined in {\tt
   thinkstats2.py}.  It is based on {\tt pyplot}, which is part of the
 {\tt matplotlib} package.  See Section~\ref{code} for information
-about installing {\tt matplotlib}.  \index{thinkplot}
+about installing {\tt matplotlib}.%
+\index{thinkplot}%
 \index{matplotlib}
 
-To plot {\tt hist} with {\tt thinkplot}, try this:
+To plot {\tt hist} with {\tt thinkplot}, try this:%
 \index{Hist}
 
 \begin{verbatim}
@@ -1615,7 +1626,7 @@ You can read the documentation for {\tt thinkplot} at
 \begin{figure}
 % first.py
 \centerline{\includegraphics[height=2.5in]{figs/first_wgt_oz_hist.pdf}}
-\caption{Histogram of the ounce part of birth weight.}
+\caption{Histogram of the ounce part of birth weight.}%
 \label{first_wgt_oz_hist}
 \end{figure}
 
@@ -1629,7 +1640,7 @@ working with this code, see Section~\ref{code}.
 
 When you start working with a new dataset, I suggest you explore
 the variables you are planning to use one at a time, and a good
-way to start is by looking at histograms.
+way to start is by looking at histograms.%
 \index{histogram}
 
 In Section~\ref{cleaning} we transformed {\tt agepreg}
@@ -1641,7 +1652,7 @@ features of histograms.
 \begin{figure}
 % first.py
 \centerline{\includegraphics[height=2.5in]{figs/first_agepreg_hist.pdf}}
-\caption{Histogram of mother's age at end of pregnancy.}
+\caption{Histogram of mother's age at end of pregnancy.}%
 \label{first_agepreg_hist}
 \end{figure}
 
@@ -1656,11 +1667,11 @@ births:
 The expression in brackets is a boolean Series that
 selects rows from the DataFrame and returns a new DataFrame.
 Next I generate and plot the histogram of
-\verb"birthwgt_lb" for live births.
-\index{DataFrame}
-\index{Series}
-\index{Hist}
-\index{bracket operator}
+\verb"birthwgt_lb" for live births.%
+\index{DataFrame}%
+\index{Series}%
+\index{Hist}%
+\index{bracket operator}%
 \index{boolean}
 
 \begin{verbatim}
@@ -1671,16 +1682,16 @@ Next I generate and plot the histogram of
 
 When the argument passed to Hist is a pandas Series, any
 {\tt nan} values are dropped.  {\tt label} is a string that appears
-in the legend when the Hist is plotted.
-\index{pandas}
-\index{Series}
-\index{thinkplot}
+in the legend when the Hist is plotted.%
+\index{pandas}%
+\index{Series}%
+\index{thinkplot}%
 \index{NaN}
 
 \begin{figure}
 % first.py
 \centerline{\includegraphics[height=2.5in]{figs/first_prglngth_hist.pdf}}
-\caption{Histogram of pregnancy length in weeks.}
+\caption{Histogram of pregnancy length in weeks.}%
 \label{first_prglngth_hist}
 \end{figure}
 
@@ -1697,8 +1708,8 @@ theory we expect this distribution to be {\bf uniform}; that is, all
 values should have the same frequency.  In fact, 0 is more common than
 the other values, and 1 and 15 are less common, probably because
 respondents round off birth weights that are close to an integer
-value.
-\index{birth weight}
+value.%
+\index{birth weight}%
 \index{weight!birth}
 
 Figure~\ref{first_agepreg_hist} shows the histogram of \verb"agepreg",
@@ -1711,7 +1722,7 @@ Figure~\ref{first_prglngth_hist} shows the histogram of
 \verb"prglngth", the length of the pregnancy in weeks.  By far the
 most common value is 39 weeks.  The left tail is longer than the
 right; early babies are common, but pregnancies seldom go past 43
-weeks, and doctors often intervene if they do.
+weeks, and doctors often intervene if they do.%
 \index{pregnancy length}
 
 
@@ -1719,18 +1730,18 @@ weeks, and doctors often intervene if they do.
 
 Looking at histograms, it is easy to identify the most common
 values and the shape of the distribution, but rare values are
-not always visible.
+not always visible.%
 \index{histogram}
 
 Before going on, it is a good idea to check for {\bf
   outliers}, which are extreme values that might be errors in
 measurement and recording, or might be accurate reports of rare
-events.
+events.%
 \index{outlier}
 
 Hist provides methods {\tt Largest} and {\tt Smallest}, which take
 an integer {\tt n} and return the {\tt n} largest or smallest
-values from the histogram:
+values from the histogram:%
 \index{Hist}
 
 \begin{verbatim}
@@ -1743,7 +1754,7 @@ are {\tt [0, 4, 9, 13, 17, 18, 19, 20, 21, 22]}.  Values below 10 weeks
 are certainly errors; the most likely explanation is that the outcome
 was not coded correctly.  Values higher than 30 weeks are probably
 legitimate.  Between 10 and 30 weeks, it is hard to be sure; some
-values are probably errors, but some represent premature babies.
+values are probably errors, but some represent premature babies.%
 \index{pregnancy length}
 
 On the other end of the range, the highest values are:
@@ -1765,7 +1776,7 @@ seems medically unlikely.
 
 The best way to handle outliers depends on ``domain knowledge'';
 that is, information about where the data come from and what they
-mean.  And it depends on what analysis you are planning to perform.
+mean.  And it depends on what analysis you are planning to perform.%
 \index{outlier}
 
 In this example, the motivating question is whether first babies
@@ -1778,9 +1789,9 @@ I will focus on pregnancies longer than 27 weeks.
 
 Now we can compare the distribution of pregnancy lengths for first
 babies and others.  I divided the DataFrame of live births using
-{\tt birthord}, and computed their histograms:
-\index{DataFrame}
-\index{Hist}
+{\tt birthord}, and computed their histograms:%
+\index{DataFrame}%
+\index{Hist}%
 \index{pregnancy length}
 
 \begin{verbatim}
@@ -1804,28 +1815,28 @@ Then I plotted their histograms on the same axis:
 
 {\tt thinkplot.PrePlot} takes the number of histograms
 we are planning to plot; it uses this information to choose
-an appropriate collection of colors.
+an appropriate collection of colors.%
 \index{thinkplot}
 
 \begin{figure}
 % first.py
 \centerline{\includegraphics[height=2.5in]{figs/first_nsfg_hist.pdf}}
-\caption{Histogram of pregnancy lengths.}
+\caption{Histogram of pregnancy lengths.}%
 \label{first_nsfg_hist}
 \end{figure}
 
 {\tt thinkplot.Hist} normally uses {\tt align='center'} so that
 each bar is centered over its value.  For this figure, I use
 {\tt align='right'} and {\tt align='left'} to place
-corresponding bars on either side of the value.
+corresponding bars on either side of the value.%
 \index{Hist}
 
 With {\tt width=0.45}, the total width of the two bars is 0.9,
 leaving some space between each pair.
 
 Finally, I adjust the axis to show only data between 27 and 46 weeks.
-Figure~\ref{first_nsfg_hist} shows the result.
-\index{pregnancy length}
+Figure~\ref{first_nsfg_hist} shows the result.%
+\index{pregnancy length}%
 \index{length!pregnancy}
 
 Histograms are useful because they make the most frequent values
@@ -1836,7 +1847,7 @@ are due to sample sizes.  In the next chapter we address this problem
 using probability mass functions.
 
 
-\section{Summarizing distributions}
+\section{Summarizing distributions}%
 \label{mean}
 
 A histogram is a complete description of the distribution of a sample;
@@ -1852,20 +1863,20 @@ Some of the characteristics we might want to report are:
 \begin{itemize}
 
 \item central tendency: Do the values tend to cluster around
-a particular point?
+a particular point?%
 \index{central tendency}
 
-\item modes: Is there more than one cluster?
+\item modes: Is there more than one cluster?%
 \index{mode}
 
-\item spread: How much variability is there in the values?
+\item spread: How much variability is there in the values?%
 \index{spread}
 
 \item tails: How quickly do the probabilities drop off as we
-move away from the modes?
+move away from the modes?%
 \index{tail}
 
-\item outliers: Are there extreme values far from the modes?
+\item outliers: Are there extreme values far from the modes?%
 \index{outlier}
 
 \end{itemize}
@@ -1873,7 +1884,10 @@ move away from the modes?
 Statistics designed to answer these questions are called {\bf summary
   statistics}.  By far the most common summary statistic is the {\bf
   mean}, which is meant to describe the central tendency of the
-distribution.  \index{mean} \index{average} \index{summary statistic}
+distribution.%
+\index{mean}%
+\index{average}%
+\index{summary statistic}
 
 If you have a sample of {\tt n} values, $x_i$, the mean, $\xbar$, is
 the sum of the values divided by the number of values; in other words
@@ -1889,7 +1903,7 @@ but I make this distinction:
   the previous formula.
 
 \item An ``average'' is one of several summary statistics you might
-  choose to describe a central tendency.
+  choose to describe a central tendency.%
 \index{central tendency}
 
 \end{itemize}
@@ -1898,7 +1912,7 @@ Sometimes the mean is a good description of a set of values.  For
 example, apples are all pretty much the same size (at least the ones
 sold in supermarkets).  So if I buy 6 apples and the total weight is 3
 pounds, it would be a reasonable summary to say they are about a half
-pound each.
+pound each.%
 \index{weight!pumpkin}
 
 But pumpkins are more diverse.  Suppose I grow several varieties in my
@@ -1907,12 +1921,12 @@ pound each, two pie pumpkins that are 3 pounds each, and one Atlantic
 Giant\textregistered~pumpkin that weighs 591 pounds.  The mean of this
 sample is 100 pounds, but if I told you ``The average pumpkin in my
 garden is 100 pounds,'' that would be misleading.  In this example,
-there is no meaningful average because there is no typical pumpkin.
+there is no meaningful average because there is no typical pumpkin.%
 \index{pumpkin}
 
 
 
-\section{Variance}
+\section{Variance}%
 \index{variance}
 
 If there is no single number that summarizes pumpkin weights,
@@ -1925,18 +1939,19 @@ or spread of a distribution.  The variance of a set of values is
 %
 The term $x_i - \xbar$ is called the ``deviation from the mean,'' so
 variance is the mean squared deviation.  The square root of variance,
-$S$, is the {\bf standard deviation}.  \index{deviation}
-\index{standard deviation}
+$S$, is the {\bf standard deviation}.%
+\index{deviation}%
+\index{standard deviation}%
 \index{deviation}
 
 If you have prior experience, you might have seen a formula for
 variance with $n-1$ in the denominator, rather than {\tt n}.  This
 statistic is used to estimate the variance in a population using a
-sample.  We will come back to this in Chapter~\ref{estimation}.
+sample.  We will come back to this in Chapter~\ref{estimation}.%
 \index{sample variance}
 
 Pandas data structures provides methods to compute mean, variance and
-standard deviation:
+standard deviation:%
 \index{pandas}
 
 \begin{verbatim}
@@ -1947,7 +1962,7 @@ standard deviation:
 
 For all live births, the mean pregnancy length is 38.6 weeks, the
 standard deviation is 2.7 weeks, which means we should expect
-deviations of 2-3 weeks to be common.
+deviations of 2-3 weeks to be common.%
 \index{pregnancy length}
 
 Variance of pregnancy length is 7.3, which is hard to interpret,
@@ -1956,24 +1971,25 @@ Variance is useful in some calculations, but it is not
 a good summary statistic.
 
 
-\section{Effect size}
+\section{Effect size}%
 \index{effect size}
 
 An {\bf effect size} is a summary statistic intended to describe (wait
 for it) the size of an effect.  For example, to describe the
 difference between two groups, one obvious choice is the difference in
-the means.  \index{effect size}
+the means.%
+\index{effect size}
 
 Mean pregnancy length for first babies is 38.601; for
 other babies it is 38.523.  The difference is 0.078 weeks, which works
 out to 13 hours.  As a fraction of the typical pregnancy length, this
-difference is about 0.2\%.
+difference is about 0.2\%.%
 \index{pregnancy length}
 
 If we assume this estimate is accurate, such a difference
 would have no practical consequences.  In fact, without
 observing a large number of pregnancies, it is unlikely that anyone
-would notice this difference at all.
+would notice this difference at all.%
 \index{effect size}
 
 Another way to convey the size of the effect is to compare the
@@ -1984,7 +2000,7 @@ Cohen's $d$ is a statistic intended to do that; it is defined
 %
 where $\bar{x_1}$ and $\bar{x_2}$ are the means of the groups and
 $s$ is the ``pooled standard deviation''.  Here's the Python
-code that computes Cohen's $d$:
+code that computes Cohen's $d$:%
 \index{standard deviation!pooled}
 
 \begin{verbatim}
@@ -2010,7 +2026,7 @@ height between men and women is about 1.7 standard deviations (see
 
 We have seen several ways to describe the difference in pregnancy
 length (if there is one) between first babies and others.  How should
-we report these results?
+we report these results?%
 \index{pregnancy length}
 
 The answer depends on who is asking the question.  A scientist might
@@ -2018,8 +2034,9 @@ be interested in any (real) effect, no matter how small.  A doctor
 might only care about effects that are {\bf clinically significant};
 that is, differences that affect treatment decisions.  A pregnant
 woman might be interested in results that are relevant to her, like
-the probability of delivering early or late.
-\index{clinically significant} \index{significant}
+the probability of delivering early or late.%
+\index{clinically significant}%
+\index{significant}
 
 How you report results also depends on your goals.  If you are trying
 to demonstrate the importance of an effect, you might choose summary
@@ -2031,7 +2048,7 @@ Of course your decisions should also be guided by professional ethics.
 It's ok to be persuasive; you {\em should\/} design statistical reports
 and visualizations that tell a story clearly.  But you should also do
 your best to make your reports honest, and to acknowledge uncertainty
-and limitations.
+and limitations.%
 \index{ethics}
 
 
@@ -2043,15 +2060,15 @@ summarize what you learned about whether first babies arrive late.
 
 Which summary statistics would you use if you wanted to get a story
 on the evening news?  Which ones would you use if you wanted to
-reassure an anxious patient?
-\index{Adams, Cecil}
+reassure an anxious patient?%
+\index{Adams, Cecil}%
 \index{Straight Dope, The}
 
 Finally, imagine that you are Cecil Adams, author of {\it The Straight
   Dope\/} (\url{http://straightdope.com}), and your job is to answer the
 question, ``Do first babies arrive late?''  Write a paragraph that
 uses the results in this chapter to answer the question clearly,
-precisely, and honestly.
+precisely, and honestly.%
 \index{ethics}
 
 \end{exercise}
@@ -2074,12 +2091,12 @@ My solution is in \verb"chap02soln.py".
 The mode of a distribution is the most frequent value; see
 \url{http://wikipedia.org/wiki/Mode_(statistics)}.  Write a function
 called {\tt Mode} that takes a Hist and returns the most
-frequent value.\index{mode}
+frequent value.\index{mode}%
 \index{Hist}
 
 As a more challenging exercise, write a function called {\tt AllModes}
 that returns a list of value-frequency pairs in descending order of
-frequency.
+frequency.%
 \index{frequency}
 \end{exercise}
 
@@ -2087,7 +2104,7 @@ frequency.
 Using the variable \verb"totalwgt_lb", investigate whether first
 babies are lighter or heavier than others.  Compute Cohen's $d$
 to quantify the difference between the groups.  How does it
-compare to the difference in pregnancy length?
+compare to the difference in pregnancy length?%
 \index{pregnancy length}
 \end{exercise}
 
@@ -2097,60 +2114,60 @@ compare to the difference in pregnancy length?
 \begin{itemize}
 
 \item distribution: The values that appear in a sample
-and the frequency of each.
+and the frequency of each.%
 \index{distribution}
 
 \item histogram: A mapping from values to frequencies, or a graph
-that shows this mapping.
+that shows this mapping.%
 \index{histogram}
 
-\item frequency: The number of times a value appears in a sample.
+\item frequency: The number of times a value appears in a sample.%
 \index{frequency}
 
 \item mode: The most frequent value in a sample, or one of the
-most frequent values.
+most frequent values.%
 \index{mode}
 
 \item normal distribution: An idealization of a bell-shaped distribution;
-also known as a Gaussian distribution. 
-\index{Gaussian distribution}
+also known as a Gaussian distribution.%
+\index{Gaussian distribution}%
 \index{normal distribution}
 
 \item uniform distribution: A distribution in which all values have
-the same frequency.
+the same frequency.%
 \index{uniform distribution}
 
-\item tail: The part of a distribution at the high and low extremes.
+\item tail: The part of a distribution at the high and low extremes.%
 \index{tail}
 
 \item central tendency: A characteristic of a sample or population;
-intuitively, it is an average or typical value. 
+intuitively, it is an average or typical value.%
 \index{central tendency}
 
-\item outlier: A value far from the central tendency.
+\item outlier: A value far from the central tendency.%
 \index{outlier}
 
 \item spread: A measure of how spread out the values in a distribution
-are.
+are.%
 \index{spread}
 
 \item summary statistic: A statistic that quantifies some aspect
-of a distribution, like central tendency or spread.
+of a distribution, like central tendency or spread.%
 \index{summary statistic}
 
-\item variance: A summary statistic often used to quantify spread.
+\item variance: A summary statistic often used to quantify spread.%
 \index{variance}
 
 \item standard deviation: The square root of variance, also used
-as a measure of spread.
+as a measure of spread.%
 \index{standard deviation}
 
 \item effect size: A summary statistic intended to quantify the size
-of an effect like a difference between groups.
+of an effect like a difference between groups.%
 \index{effect size}
 
 \item clinically significant: A result, like a difference between groups,
-that is relevant in practice.
+that is relevant in practice.%
 \index{clinically significant}
 
 \end{itemize}
@@ -2158,7 +2175,7 @@ that is relevant in practice.
 
 
 
-\chapter{Probability mass functions}
+\chapter{Probability mass functions}%
 \index{probability mass function}
 
 The code for this chapter is in {\tt probability.py}.
@@ -2166,22 +2183,23 @@ For information about downloading and
 working with this code, see Section~\ref{code}.
 
 
-\section{Pmfs}
+\section{Pmfs}%
 \index{Pmf}
 
 Another way to represent a distribution is a {\bf probability mass
   function} (PMF), which maps from each value to its probability.  A
 {\bf probability} is a frequency expressed as a fraction of the sample
 size, {\tt n}.  To get from frequencies to probabilities, we divide
-through by {\tt n}, which is called {\bf normalization}.
-\index{frequency}
-\index{probability}
-\index{normalization}
-\index{PMF}
+through by {\tt n}, which is called {\bf normalization}.%
+\index{frequency}%
+\index{probability}%
+\index{normalization}%
+\index{PMF}%
 \index{probability mass function}
 
 Given a Hist, we can make a dictionary that maps from each
-value to its probability: \index{Hist}
+value to its probability:%
+\index{Hist}
 %
 \begin{verbatim}
 n = hist.Total()
@@ -2208,7 +2226,7 @@ Pmf and Hist objects are similar in many ways; in fact, they inherit
 many of their methods from a common parent class.  For example, the
 methods {\tt Values} and {\tt Items} work the same way for both.  The
 biggest difference is that a Hist maps from values to integer
-counters; a Pmf maps from values to floating-point probabilities.
+counters; a Pmf maps from values to floating-point probabilities.%
 \index{Hist}
 
 To look up the probability associated with a value, use {\tt Prob}:
@@ -2218,7 +2236,7 @@ To look up the probability associated with a value, use {\tt Prob}:
 0.4
 \end{verbatim}
 
-The bracket operator is equivalent:
+The bracket operator is equivalent:%
 \index{bracket operator}
 
 \begin{verbatim}
@@ -2261,7 +2279,7 @@ To renormalize, call {\tt Normalize}:
 \end{verbatim}
 
 Pmf objects provide a {\tt Copy} method so you can make
-and modify a copy without affecting the original.
+and modify a copy without affecting the original.%
 \index{Pmf}
 
 My notation in this section might seem inconsistent, but there is a
@@ -2270,49 +2288,49 @@ of the class, and PMF for the mathematical concept of a
 probability mass function.
 
 
-\section{Plotting PMFs}
+\section{Plotting PMFs}%
 \index{PMF}
 
-{\tt thinkplot} provides two ways to plot Pmfs:
+{\tt thinkplot} provides two ways to plot Pmfs:%
 \index{thinkplot}
 
 \begin{itemize}
 
 \item To plot a Pmf as a bar graph, you can use 
 {\tt thinkplot.Hist}.  Bar graphs are most useful if the number
-of values in the Pmf is small.
-\index{bar plot}
+of values in the Pmf is small.%
+\index{bar plot}%
 \index{plot!bar}
 
 \item To plot a Pmf as a step function, you can use
 {\tt thinkplot.Pmf}.  This option is most useful if there are
 a large number of values and the Pmf is smooth.  This function
-also works with Hist objects.
-\index{line plot}
-\index{plot!line}
-\index{Hist}
+also works with Hist objects.%
+\index{line plot}%
+\index{plot!line}%
+\index{Hist}%
 \index{Pmf}
 
 \end{itemize}
 
 In addition, {\tt pyplot} provides a function called {\tt hist} that
 takes a sequence of values, computes a histogram, and plots it.
-Since I use Hist objects, I usually don't use {\tt pyplot.hist}.
+Since I use Hist objects, I usually don't use {\tt pyplot.hist}.%
 \index{pyplot}
 
 \begin{figure}
 % probability.py
 \centerline{\includegraphics[height=3.0in]{figs/probability_nsfg_pmf.pdf}}
 \caption{PMF of pregnancy lengths for first babies and others, using
-  bar graphs and step functions.}
+  bar graphs and step functions.}%
 \label{probability_nsfg_pmf}
-\end{figure}
-\index{pregnancy length}
+\end{figure}%
+\index{pregnancy length}%
 \index{length!pregnancy}
 
 Figure~\ref{probability_nsfg_pmf} shows PMFs of pregnancy length for
 first babies and others using bar graphs (left) and step functions
-(right).
+(right).%
 \index{pregnancy length}
 
 By plotting the PMF instead of the histogram, we can compare the two
@@ -2341,8 +2359,8 @@ Here's the code that generates Figure~\ref{probability_nsfg_pmf}:
 {\tt PrePlot} takes optional parameters {\tt rows} and {\tt cols}
 to make a grid of figures, in this case one row of two figures.
 The first figure (on the left) displays the Pmfs using {\tt thinkplot.Hist},
-as we have seen before.
-\index{thinkplot}
+as we have seen before.%
+\index{thinkplot}%
 \index{Hist}
 
 The second call to {\tt PrePlot} resets the color generator.  Then
@@ -2352,21 +2370,21 @@ to ensure that the two figures are on the same axes, which is
 generally a good idea if you intend to compare two figures.
 
 
-\section{Other visualizations}
+\section{Other visualizations}%
 \label{visualization}
 
 Histograms and PMFs are useful while you are exploring data and
 trying to identify patterns and relationships.
 Once you have an idea what is going on, a good next step is to
 design a visualization that makes the patterns you have identified
-as clear as possible.
-\index{exploratory data analysis}
+as clear as possible.%
+\index{exploratory data analysis}%
 \index{visualization}
 
 In the NSFG data, the biggest differences in the distributions are
 near the mode.  So it makes sense to zoom in on that part of the
-graph, and to transform the data to emphasize differences:
-\index{National Survey of Family Growth}
+graph, and to transform the data to emphasize differences:%
+\index{National Survey of Family Growth}%
 \index{NSFG}
 
 \begin{verbatim}
@@ -2386,13 +2404,13 @@ difference between the two PMFs in percentage points.
 Figure~\ref{probability_nsfg_diffs} shows the result as a bar chart.
 This figure makes the pattern clearer: first babies are less likely to
 be born in week 39, and somewhat more likely to be born in weeks 41
-and 42.
+and 42.%
 \index{thinkplot}
 
 \begin{figure}
 % probability.py
 \centerline{\includegraphics[height=2.5in]{figs/probability_nsfg_diffs.pdf}}
-\caption{Difference, in percentage points, by week.}
+\caption{Difference, in percentage points, by week.}%
 \label{probability_nsfg_diffs}
 \end{figure}
 
@@ -2404,12 +2422,12 @@ it might be due to random variation.  We'll address this concern
 later.
 
 
-\section{The class size paradox}
+\section{The class size paradox}%
 \index{class size}
 
 Before we go on, I want to demonstrate
 one kind of computation you can do with Pmf objects; I call
-this example the ``class size paradox.''
+this example the ``class size paradox.''%
 \index{Pmf}
 
 At many American colleges and universities, the student-to-faculty
@@ -2465,8 +2483,8 @@ much bigger.
 First, I compute the
 distribution as observed by students, where the probability
 associated with each class size is ``biased'' by the number
-of students in the class.
-\index{observer bias}
+of students in the class.%
+\index{observer bias}%
 \index{bias!observer}
 
 \begin{verbatim}
@@ -2484,7 +2502,7 @@ For each class size, {\tt x}, we multiply the probability by
 {\tt x}, the number of students who observe that class size.
 The result is a new Pmf that represents the biased distribution.
 
-Now we can plot the actual and observed distributions:
+Now we can plot the actual and observed distributions:%
 \index{thinkplot}
 
 \begin{verbatim}
@@ -2497,7 +2515,7 @@ Now we can plot the actual and observed distributions:
 \begin{figure}
 % probability.py
 \centerline{\includegraphics[height=3.0in]{figs/class_size1.pdf}}
-\caption{Distribution of class sizes, actual and as observed by students.}
+\caption{Distribution of class sizes, actual and as observed by students.}%
 \label{class_size1}
 \end{figure}
 
@@ -2510,7 +2528,9 @@ It is also possible to invert this operation.  Suppose you want to
 find the distribution of class sizes at a college, but you can't get
 reliable data from the Dean.  An alternative is to choose a random
 sample of students and ask how many students are in their
-classes.  \index{bias!oversampling} \index{oversampling}
+classes.%
+\index{bias!oversampling}%
+\index{oversampling}
 
 The result would be biased for the reasons we've just seen, but you
 can use it to estimate the actual distribution.  Here's the function
@@ -2536,9 +2556,9 @@ divides each probability by {\tt x} instead of multiplying.
 In Section~\ref{dataframe} we read a pandas DataFrame and used it to
 select and modify data columns.  Now let's look at row selection.
 To start, I create a NumPy array of random numbers and use it
-to initialize a DataFrame:
-\index{NumPy}
-\index{pandas}
+to initialize a DataFrame:%
+\index{NumPy}%
+\index{pandas}%
 \index{DataFrame}
 
 \begin{verbatim}
@@ -2583,7 +2603,7 @@ d -1.369968  0.545897
 \end{verbatim}
 
 As we saw in the previous chapter, simple indexing selects a
-column, returning a Series:
+column, returning a Series:%
 \index{Series}
 
 \begin{verbatim}
@@ -2646,7 +2666,7 @@ b -1.489647  0.300774
 \end{verbatim}
 
 The result in either case is a DataFrame, but notice that the first
-result includes the end of the slice; the second doesn't.
+result includes the end of the slice; the second doesn't.%
 \index{DataFrame}
 
 My advice: if your rows have labels that are not simple integers, use
@@ -2663,8 +2683,8 @@ and \verb"chap03soln.py"
 Something like the class size paradox appears if you survey children
 and ask how many children are in their family.  Families with many
 children are more likely to appear in your sample, and
-families with no children have no chance to be in the sample.
-\index{observer bias}
+families with no children have no chance to be in the sample.%
+\index{observer bias}%
 \index{bias!observer}
 
 Use the NSFG respondent variable \verb"NUMKDHH" to construct the actual
@@ -2679,9 +2699,9 @@ As a starting place, you can use \verb"chap03ex.ipynb".
 \end{exercise}
 
 
-\begin{exercise}
-\index{mean}
-\index{variance}
+\begin{exercise}%
+\index{mean}%
+\index{variance}%
 \index{PMF}
 
 In Section~\ref{mean} we computed the mean of a sample by adding up
@@ -2698,7 +2718,7 @@ Similarly, you can compute variance like this:
 Write functions called {\tt PmfMean} and {\tt PmfVar} that take a
 Pmf object and compute the mean and variance.  To test these methods,
 check that they are consistent with the methods {\tt Mean} and {\tt
-  Var} provided by Pmf.
+  Var} provided by Pmf.%
 \index{Pmf}
 
 \end{exercise}
@@ -2719,13 +2739,13 @@ Hint: use {\tt nsfg.MakePregMap}.
 \end{exercise}
 
 
-\begin{exercise}
+\begin{exercise}%
 \label{relay}
 
 In most foot races, everyone starts at the same time.  If you are a
 fast runner, you usually pass a lot of people at the beginning of the
 race, but after a few miles everyone around you is going at the same
-speed.
+speed.%
 \index{relay race}
 
 When I ran a long-distance (209 miles) relay race for the first
@@ -2741,7 +2761,9 @@ Then I realized that I was the victim of a bias similar to the
 effect of class size.  The race
 was unusual in two ways: it used a staggered start, so teams started
 at different times; also, many teams included runners at different
-levels of ability. \index{bias!selection} \index{selection bias}
+levels of ability.%
+\index{bias!selection}%
+\index{selection bias}
 
 As a result, runners were spread out along the course with little
 relationship between speed and location.  When I joined the race, the
@@ -2757,8 +2779,8 @@ at the same speed are unlikely to see each other.
 Write a function called {\tt ObservedPmf} that takes a Pmf representing
 the actual distribution of runners' speeds, and the speed of a running
 observer, and returns a new Pmf representing the distribution of
-runners' speeds as seen by the observer.
-\index{observer bias}
+runners' speeds as seen by the observer.%
+\index{observer bias}%
 \index{bias!observer}
 
 To test your function, you can use {\tt relay.py}, which  reads the
@@ -2776,28 +2798,28 @@ exercise is in \verb"relay_soln.py".
 \begin{itemize}
 
 \item Probability mass function (PMF): a representation of a distribution
-as a function that maps from values to probabilities.
-\index{PMF}
+as a function that maps from values to probabilities.%
+\index{PMF}%
 \index{probability mass function}
 
 \item probability: A frequency expressed as a fraction of the sample
-size.
-\index{frequency}
+size.%
+\index{frequency}%
 \index{probability}
 
 \item normalization: The process of dividing a frequency by a sample
-size to get a probability.
+size to get a probability.%
 \index{normalization}
 
 \item index: In a pandas DataFrame, the index is a special column
-that contains the row labels.
-\index{pandas}
+that contains the row labels.%
+\index{pandas}%
 \index{DataFrame}
 
 \end{itemize}
 
 
-\chapter{Cumulative distribution functions}
+\chapter{Cumulative distribution functions}%
 \label{cumulative}
 
 The code for this chapter is in {\tt cumulative.py}.
@@ -2805,7 +2827,7 @@ For information about downloading and
 working with this code, see Section~\ref{code}.
 
 
-\section{The limits of PMFs}
+\section{The limits of PMFs}%
 \index{PMF}
 
 PMFs work well if the number of values is small.  But as the number of
@@ -2815,15 +2837,17 @@ smaller and the effect of random noise increases.
 For example, we might be interested in the distribution of birth
 weights.  In the NSFG data, the variable \verb"totalwgt_lb" records
 weight at birth in pounds.  Figure~\ref{nsfg_birthwgt_pmf} shows
-the PMF of these values for first babies and others.
-\index{National Survey of Family Growth} \index{NSFG} \index{birth weight}
+the PMF of these values for first babies and others.%
+\index{National Survey of Family Growth}%
+\index{NSFG}%
+\index{birth weight}%
 \index{weight!birth}
 
 \begin{figure}
 % cumulative.py
 \centerline{\includegraphics[height=2.5in]{figs/nsfg_birthwgt_pmf.pdf}}
 \caption{PMF of birth weights.  This figure shows a limitation
-of PMFs: they are hard to compare visually.}
+of PMFs: they are hard to compare visually.}%
 \label{nsfg_birthwgt_pmf}
 \end{figure}
 
@@ -2835,7 +2859,7 @@ But parts of this figure are hard to interpret.  There are many spikes
 and valleys, and some apparent differences between the distributions.
 It is hard to tell which of these features are meaningful.  Also, it
 is hard to see overall patterns; for example, which distribution do
-you think has the higher mean?
+you think has the higher mean?%
 \index{binning}
 
 These problems can be mitigated by binning the data; that is, dividing
@@ -2846,11 +2870,11 @@ out noise, they might also smooth out useful information.
 
 An alternative that avoids these problems is the cumulative
 distribution function (CDF), which is the subject of this chapter.
-But before I can explain CDFs, I have to explain percentiles.
+But before I can explain CDFs, I have to explain percentiles.%
 \index{CDF}
 
 
-\section{Percentiles}
+\section{Percentiles}%
 \index{percentile rank}
 
 If you have taken a standardized test, you probably got your
@@ -2894,7 +2918,7 @@ def Percentile(scores, percentile_rank):
 
 The result of this calculation is a {\bf percentile}.  For example,
 the 50th percentile is the value with percentile rank 50.  In the
-distribution of exam scores, the 50th percentile is 77.
+distribution of exam scores, the 50th percentile is 77.%
 \index{percentile}
 
 This implementation of {\tt Percentile} is not efficient.  A
@@ -2912,18 +2936,18 @@ The difference between ``percentile'' and ``percentile rank'' can
 be confusing, and people do not always use the terms precisely.
 To summarize, {\tt PercentileRank} takes a value and computes
 its percentile rank in a set of values; {\tt Percentile} takes
-a percentile rank and computes the corresponding value.
+a percentile rank and computes the corresponding value.%
 \index{percentile rank}
 
 
-\section{CDFs}
+\section{CDFs}%
 \index{CDF}
 
 Now that we understand percentiles and percentile ranks,
 we are ready to tackle the {\bf cumulative distribution function}
 (CDF).  The CDF is the function that maps from a value to its
-percentile rank.
-\index{cumulative distribution function}
+percentile rank.%
+\index{cumulative distribution function}%
 \index{percentile rank}
 
 The CDF is a function of $x$, where $x$ is any value that might appear
@@ -2947,7 +2971,7 @@ def EvalCdf(sample, x):
 
 This function is almost identical to {\tt PercentileRank}, except that
 the result is a probability in the range 0--1 rather than a
-percentile rank in the range 0--100.
+percentile rank in the range 0--100.%
 \index{sample}
 
 As an example, suppose we collect a sample with the values 
@@ -2973,16 +2997,16 @@ If $x$ is greater than the largest value, $\CDF(x)$ is 1.
 \begin{figure}
 % cumulative.py
 \centerline{\includegraphics[height=2.5in]{figs/cumulative_example_cdf.pdf}}
-\caption{Example of a CDF.}
+\caption{Example of a CDF.}%
 \label{example_cdf}
 \end{figure}
 
 Figure~\ref{example_cdf} is a graphical representation of this CDF.
-The CDF of a sample is a step function.
+The CDF of a sample is a step function.%
 \index{step function}
 
 
-\section{Representing CDFs}
+\section{Representing CDFs}%
 \index{Cdf}
 
 {\tt thinkstats2} provides a class named Cdf that represents
@@ -2991,12 +3015,12 @@ CDFs.  The fundamental methods Cdf provides are:
 \begin{itemize}
 
 \item {\tt Prob(x)}: Given a value {\tt x}, computes the probability
-  $p = \CDF(x)$.  The bracket operator is equivalent to {\tt Prob}.
+  $p = \CDF(x)$.  The bracket operator is equivalent to {\tt Prob}.%
 \index{bracket operator}
 
 \item {\tt Value(p)}: Given a probability {\tt p}, computes the
-corresponding value, {\tt x}; that is, the {\bf inverse CDF} of {\tt p}.
-\index{inverse CDF}
+corresponding value, {\tt x}; that is, the {\bf inverse CDF} of {\tt p}.%
+\index{inverse CDF}%
 \index{CDF, inverse}
 
 \end{itemize}
@@ -3004,15 +3028,15 @@ corresponding value, {\tt x}; that is, the {\bf inverse CDF} of {\tt p}.
 \begin{figure}
 % cumulative.py
 \centerline{\includegraphics[height=2.5in]{figs/cumulative_prglngth_cdf.pdf}}
-\caption{CDF of pregnancy length.}
+\caption{CDF of pregnancy length.}%
 \label{cumulative_prglngth_cdf}
 \end{figure}
 
 The Cdf constructor can take as an argument a list of values,
 a pandas Series, a Hist, Pmf, or another Cdf.  The following
 code makes a Cdf for the distribution of pregnancy lengths in
-the NSFG:
-\index{NSFG}
+the NSFG:%
+\index{NSFG}%
 \index{pregnancy length}
 
 \begin{verbatim}
@@ -3021,7 +3045,7 @@ the NSFG:
 \end{verbatim}
 
 {\tt thinkplot} provides a function named {\tt Cdf} that
-plots Cdfs as lines:
+plots Cdfs as lines:%
 \index{thinkplot}
 
 \begin{verbatim}
@@ -3036,7 +3060,7 @@ are shorter than 41 weeks.  The CDF also provides a visual
 representation of the shape of the distribution.  Common values appear
 as steep or vertical sections of the CDF; in this example, the mode at
 39 weeks is apparent.  There are few values below 30 weeks, so
-the CDF in this range is flat.
+the CDF in this range is flat.%
 \index{CDF, interpreting}
 
 It takes some time to get used to CDFs, but once you
@@ -3044,17 +3068,17 @@ do, I think you will find that they show more information, more
 clearly, than PMFs.
 
 
-\section{Comparing CDFs}
-\label{birth_weights}
-\index{National Survey of Family Growth}
-\index{NSFG}
-\index{birth weight}
+\section{Comparing CDFs}%
+\label{birth_weights}%
+\index{National Survey of Family Growth}%
+\index{NSFG}%
+\index{birth weight}%
 \index{weight!birth}
 
 CDFs are especially useful for comparing distributions.  For
 example, here is the code that plots the CDF of birth
-weight for first babies and others.
-\index{thinkplot}
+weight for first babies and others.%
+\index{thinkplot}%
 \index{distributions, comparing}
 
 \begin{verbatim}
@@ -3069,7 +3093,7 @@ weight for first babies and others.
 \begin{figure}
 % cumulative.py
 \centerline{\includegraphics[height=2.5in]{figs/cumulative_birthwgt_cdf.pdf}}
-\caption{CDF of birth weights for first babies and others.}
+\caption{CDF of birth weights for first babies and others.}%
 \label{cumulative_birthwgt_cdf}
 \end{figure}
 
@@ -3077,25 +3101,25 @@ Figure~\ref{cumulative_birthwgt_cdf} shows the result.
 Compared to Figure~\ref{nsfg_birthwgt_pmf},
 this figure makes the shape of the distributions, and the differences
 between them, much clearer.  We can see that first babies are slightly
-lighter throughout the distribution, with a larger discrepancy above 
-the mean.
+lighter throughout the distribution, with a larger discrepancy above
+the mean.%
 \index{shape}
 
 
 
 
-\section{Percentile-based statistics}
-\index{summary statistic}
-\index{interquartile range}
-\index{quartile}
-\index{percentile}
-\index{median}
-\index{central tendency}
+\section{Percentile-based statistics}%
+\index{summary statistic}%
+\index{interquartile range}%
+\index{quartile}%
+\index{percentile}%
+\index{median}%
+\index{central tendency}%
 \index{spread}
 
 Once you have computed a CDF, it is easy to compute percentiles
-and percentile ranks.  The Cdf class provides these two methods:
-\index{Cdf}
+and percentile ranks.  The Cdf class provides these two methods:%
+\index{Cdf}%
 \index{percentile rank}
 
 \begin{itemize}
@@ -3129,27 +3153,27 @@ often reported in ``quintiles''; that is, it is split at the
 20th, 40th, 60th and 80th percentiles.  Other distributions
 are divided into ten ``deciles''.  Statistics like these that represent
 equally-spaced points in a CDF are called {\bf quantiles}.
-For more, see \url{https://en.wikipedia.org/wiki/Quantile}.
-\index{quantile}
-\index{quintile}
+For more, see \url{https://en.wikipedia.org/wiki/Quantile}.%
+\index{quantile}%
+\index{quintile}%
 \index{decile}
 
 
 
-\section{Random numbers}
-\label{random}
+\section{Random numbers}%
+\label{random}%
 \index{random number}
 
 Suppose we choose a random sample from the population of live
 births and look up the percentile rank of their birth weights.
 Now suppose we compute the CDF of the percentile ranks.  What do
-you think the distribution will look like?
-\index{percentile rank}
-\index{birth weight}
+you think the distribution will look like?%
+\index{percentile rank}%
+\index{birth weight}%
 \index{weight!birth}
 
 Here's how we can compute it.  First, we make the Cdf of
-birth weights:
+birth weights:%
 \index{Cdf}
 
 \begin{verbatim}
@@ -3168,10 +3192,10 @@ each value in the sample.
 {\tt sample}
 is a random sample of 100 birth weights, chosen with {\bf replacement};
 that is, the same value could be chosen more than once.  {\tt ranks}
-is a list of percentile ranks.
+is a list of percentile ranks.%
 \index{replacement}
 
-Finally we make and plot the Cdf of the percentile ranks.
+Finally we make and plot the Cdf of the percentile ranks.%
 \index{thinkplot}
 
 \begin{verbatim}
@@ -3183,7 +3207,7 @@ Finally we make and plot the Cdf of the percentile ranks.
 \begin{figure}
 % cumulative.py
 \centerline{\includegraphics[height=2.5in]{figs/cumulative_random.pdf}}
-\caption{CDF of percentile ranks for a random sample of birth weights.}
+\caption{CDF of percentile ranks for a random sample of birth weights.}%
 \label{cumulative_random}
 \end{figure}
 
@@ -3199,8 +3223,8 @@ of the sample is below the 10th percentile, 20\% is below the
 So, regardless of the shape of the CDF, the distribution of
 percentile ranks is uniform.  This property is useful, because it
 is the basis of a simple and efficient algorithm for generating
-random numbers with a given CDF.  Here's how:
-\index{inverse CDF algorithm}
+random numbers with a given CDF.  Here's how:%
+\index{inverse CDF algorithm}%
 \index{random number}
 
 \begin{itemize}
@@ -3208,7 +3232,7 @@ random numbers with a given CDF.  Here's how:
 \item Choose a percentile rank uniformly from the range 0--100.
 
 \item Use {\tt Cdf.Percentile} to find the value in the distribution
-that corresponds to the percentile rank you chose.
+that corresponds to the percentile rank you chose.%
 \index{Cdf}
 
 \end{itemize}
@@ -3232,16 +3256,18 @@ from the Cdf.
 Percentile ranks are useful for comparing measurements across
 different groups.  For example, people who compete in foot races are
 usually grouped by age and gender.  To compare people in different
-age groups, you can convert race times to percentile ranks.
+age groups, you can convert race times to percentile ranks.%
 \index{percentile rank}
 
 A few years ago I ran the James Joyce Ramble 10K in
 Dedham MA; I finished in 42:44, which was 97th in a field of 1633.  I beat or
 tied 1537 runners out of 1633, so my percentile rank in the field is
-94\%.  \index{James Joyce Ramble} \index{race time}
+94\%.%
+\index{James Joyce Ramble}%
+\index{race time}
 
 More generally, given position and field size, we can compute
-percentile rank:
+percentile rank:%
 \index{field size}
 
 \begin{verbatim}
@@ -3253,7 +3279,7 @@ def PositionToPercentile(position, field_size):
 
 In my age group, denoted M4049 for ``male between 40 and 49 years of
 age'', I came in 26th out of 256.  So my percentile rank in my age
-group was 90\%.
+group was 90\%.%
 \index{age group}
 
 If I am still running in 10 years (and I hope I am), I will be in
@@ -3288,8 +3314,8 @@ compute the distribution of birth weights and use it to find your
 percentile rank.  If you were a first baby, find your percentile rank
 in the distribution for first babies.  Otherwise use the distribution
 for others.  If you are in the 90th percentile or higher, call your
-mother back and apologize.
-\index{birth weight}
+mother back and apologize.%
+\index{birth weight}%
 \index{weight!birth}
 
 \end{exercise}
@@ -3300,9 +3326,9 @@ uniform between 0 and 1; that is, every value in the range
 should have the same probability.
 
 Generate 1000 numbers from {\tt random.random} and plot their
-PMF and CDF.  Is the distribution uniform?
-\index{uniform distribution}
-\index{distribution!uniform}
+PMF and CDF.  Is the distribution uniform?%
+\index{uniform distribution}%
+\index{distribution!uniform}%
 \index{random number}
 
 \end{exercise}
@@ -3313,52 +3339,54 @@ PMF and CDF.  Is the distribution uniform?
 \begin{itemize}
 
 \item percentile rank: The percentage of values in a distribution that are
-less than or equal to a given value.
+less than or equal to a given value.%
 \index{percentile rank}
 
-\item percentile: The value associated with a given percentile rank.
+\item percentile: The value associated with a given percentile rank.%
 \index{percentile}
 
 \item cumulative distribution function (CDF): A function that maps
   from values to their cumulative probabilities.  $\CDF(x)$ is the
-  fraction of the sample less than or equal to $x$.  \index{CDF}
+  fraction of the sample less than or equal to $x$.%
+\index{CDF}%
 \index{cumulative probability}
 
 \item inverse CDF: A function that maps from a cumulative probability,
-  $p$, to the corresponding value.
-\index{inverse CDF}
+  $p$, to the corresponding value.%
+\index{inverse CDF}%
 \index{CDF, inverse}
 
 \item median: The 50th percentile, often used as a measure of central
-  tendency.  \index{median}
+  tendency.%
+\index{median}
 
 \item interquartile range: The difference between
-the 75th and 25th percentiles, used as a measure of spread.
+the 75th and 25th percentiles, used as a measure of spread.%
 \index{interquartile range}
 
 \item quantile: A sequence of values that correspond to equally spaced
 percentile ranks; for example, the quartiles of a distribution are
-the 25th, 50th and 75th percentiles.
+the 25th, 50th and 75th percentiles.%
 \index{quantile}
 
 \item replacement: A property of a sampling process. ``With replacement''
 means that the same value can be chosen more than once; ``without
 replacement'' means that once a value is chosen, it is removed from
-the population.
+the population.%
 \index{replacement}
 
 \end{itemize}
 
 
-\chapter{Modeling distributions}
+\chapter{Modeling distributions}%
 \label{modeling}
 
 The distributions we have used so far are called {\bf empirical
   distributions} because they are based on empirical observations,
-which are necessarily finite samples.
-\index{analytic distribution}
-\index{distribution!analytic}
-\index{empirical distribution}
+which are necessarily finite samples.%
+\index{analytic distribution}%
+\index{distribution!analytic}%
+\index{empirical distribution}%
 \index{distribution!empirical}
 
 The alternative is an {\bf analytic distribution}, which is
@@ -3366,7 +3394,7 @@ characterized by a CDF that is a mathematical function.
 Analytic distributions can be used to model empirical distributions.
 In this context, a {\bf model} is a simplification that leaves out
 unneeded details.  This chapter presents common analytic distributions
-and uses them to model data from a variety of sources.
+and uses them to model data from a variety of sources.%
 \index{model}
 
 The code for this chapter is in {\tt analytic.py}.  For information
@@ -3374,15 +3402,15 @@ about downloading and working with this code, see Section~\ref{code}.
 
 
 
-\section{The exponential distribution}
-\label{exponential}
-\index{exponential distribution}
+\section{The exponential distribution}%
+\label{exponential}%
+\index{exponential distribution}%
 \index{distribution!exponential}
 
 \begin{figure}
 % analytic.py
 \centerline{\includegraphics[height=2.5in]{figs/analytic_expo_cdf.pdf}}
-\caption{CDFs of exponential distributions with various parameters.}
+\caption{CDFs of exponential distributions with various parameters.}%
 \label{analytic_expo_cdf}
 \end{figure}
 
@@ -3393,14 +3421,14 @@ relatively simple.  The CDF of the exponential distribution is
 %
 The parameter, $\lambda$, determines the shape of the distribution.
 Figure~\ref{analytic_expo_cdf} shows what this CDF looks like with
-$\lambda = $ 0.5, 1, and 2.
-  \index{parameter}
+$\lambda = $ 0.5, 1, and 2.%
+\index{parameter}
 
 In the real world, exponential distributions
 come up when we look at a series of events and measure the
 times between events, called {\bf interarrival times}.
 If the events are equally likely to occur at any time, the distribution
-of interarrival times tends to look like an exponential distribution.
+of interarrival times tends to look like an exponential distribution.%
 \index{interarrival time}
 
 As an example, we will look at the interarrival time of births.
@@ -3410,9 +3438,10 @@ Australia.\footnote{This example is based on information and data from
   Journal of Statistics Education v.7, n.3 (1999).}  The time of
 birth for all 44 babies was reported in the local paper; the
 complete dataset is in a file called {\tt babyboom.dat}, in the
-{\tt ThinkStats2} repository.
-\index{birth time}
-\index{Australia} \index{Brisbane}
+{\tt ThinkStats2} repository.%
+\index{birth time}%
+\index{Australia}%
+\index{Brisbane}
 
 \begin{verbatim}
     df = ReadBabyBoom()
@@ -3426,14 +3455,14 @@ complete dataset is in a file called {\tt babyboom.dat}, in the
 {\tt ReadBabyBoom} reads the data file and returns a DataFrame
 with columns {\tt time}, {\tt sex}, \verb"weight_g", and {\tt minutes},
 where {\tt minutes} is time of birth converted to minutes since
-midnight.
-\index{DataFrame}
+midnight.%
+\index{DataFrame}%
 \index{thinkplot}
 
 \begin{figure}
 % analytic.py
 \centerline{\includegraphics[height=2.5in]{figs/analytic_interarrivals.pdf}}
-\caption{CDF of interarrival times (left) and CCDF on a log-y scale (right).}
+\caption{CDF of interarrival times (left) and CCDF on a log-y scale (right).}%
 \label{analytic_interarrival_cdf}
 \end{figure}
 
@@ -3452,8 +3481,10 @@ we tell?
 
 One way is to plot the {\bf complementary CDF}, which is $1 - \CDF(x)$,
 on a log-y scale.  For data from an exponential distribution, the
-result is a straight line.  Let's see why that works.
-\index{complementary CDF} \index{CDF!complementary} \index{CCDF}
+result is a straight line.  Let's see why that works.%
+\index{complementary CDF}%
+\index{CDF!complementary}%
+\index{CCDF}
 
 If you plot the complementary CDF (CCDF) of a dataset that you think is
 exponential, you expect to see a function like:
@@ -3465,10 +3496,10 @@ Taking the log of both sides yields:
 \[ \log y \approx -\lambda x\]
 %
 So on a log-y scale the CCDF is a straight line
-with slope $-\lambda$.  Here's how we can generate a plot like that:
-\index{logarithmic scale}
-\index{complementary CDF}
-\index{CDF!complementary}
+with slope $-\lambda$.  Here's how we can generate a plot like that:%
+\index{logarithmic scale}%
+\index{complementary CDF}%
+\index{CDF!complementary}%
 \index{CCDF}
 
 
@@ -3481,8 +3512,8 @@ with slope $-\lambda$.  Here's how we can generate a plot like that:
 
 With the argument {\tt complement=True}, {\tt thinkplot.Cdf} computes
 the complementary CDF before plotting.  And with {\tt yscale='log'},
-{\tt thinkplot.Show} sets the {\tt y} axis to a logarithmic scale.
-\index{thinkplot}
+{\tt thinkplot.Show} sets the {\tt y} axis to a logarithmic scale.%
+\index{thinkplot}%
 \index{Cdf}
 
 Figure~\ref{analytic_interarrival_cdf} (right) shows the result.  It is not
@@ -3491,7 +3522,7 @@ not a perfect model for this data.  Most likely the underlying
 assumption---that a birth is equally likely at any time of day---is
 not exactly true.  Nevertheless, it might be reasonable to model this
 dataset with an exponential distribution.  With that simplification, we can
-summarize the distribution with a single parameter.
+summarize the distribution with a single parameter.%
 \index{model}
 
 The parameter, $\lambda$, can be interpreted as a rate; that is, the
@@ -3501,20 +3532,20 @@ example, 44 babies are born in 24 hours, so the rate is $\lambda =
 $1/\lambda$, so the mean time between births is 32.7 minutes.
 
 
-\section{The normal distribution}
+\section{The normal distribution}%
 \label{normal}
 
 The {\bf normal distribution}, also called Gaussian, is commonly
 used because it describes many phenomena, at least approximately.
 It turns out that there is a good reason for its ubiquity, which we
-will get to in Section~\ref{CLT}.
-\index{CDF}
-\index{parameter}
-\index{mean}
-\index{standard deviation}
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
+will get to in Section~\ref{CLT}.%
+\index{CDF}%
+\index{parameter}%
+\index{mean}%
+\index{standard deviation}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
 \index{distribution!Gaussian}
 
 %
@@ -3524,7 +3555,7 @@ will get to in Section~\ref{CLT}.
 \begin{figure}
 % analytic.py
 \centerline{\includegraphics[height=2.5in]{figs/analytic_gaussian_cdf.pdf}}
-\caption{CDF of normal distributions with a range of parameters.}
+\caption{CDF of normal distributions with a range of parameters.}%
 \label{analytic_gaussian_cdf}
 \end{figure}
 
@@ -3535,8 +3566,8 @@ $\mu=0$ and $\sigma=1$ is called the {\bf standard normal
 a closed form solution, but there are algorithms that evaluate it
 efficiently.  One of them is provided by SciPy: {\tt scipy.stats.norm}
 is an object that represents a normal distribution; it provides a
-method, {\tt cdf}, that evaluates the standard normal CDF:
-\index{SciPy}
+method, {\tt cdf}, that evaluates the standard normal CDF:%
+\index{SciPy}%
 \index{closed form}
 
 \begin{verbatim}
@@ -3555,7 +3586,7 @@ standard deviation.
 
 {\tt thinkstats2} makes this function a little easier to use
 by providing {\tt EvalNormalCdf}, which takes parameters {\tt mu}
-and {\tt sigma} and evaluates the CDF at {\tt x}:
+and {\tt sigma} and evaluates the CDF at {\tt x}:%
 \index{normal distribution}
 
 \begin{verbatim}
@@ -3570,24 +3601,24 @@ curves is a recognizable characteristic of a normal distribution.
 In the previous chapter we looked at the distribution of birth
 weights in the NSFG.  Figure~\ref{analytic_birthwgt_model} shows the
 empirical CDF of weights for all live births and the CDF of
-a normal distribution with the same mean and variance.
-\index{National Survey of Family Growth}
-\index{NSFG}
-\index{birth weight}
+a normal distribution with the same mean and variance.%
+\index{National Survey of Family Growth}%
+\index{NSFG}%
+\index{birth weight}%
 \index{weight!birth}
 
 \begin{figure}
 % analytic.py
 \centerline{\includegraphics[height=2.5in]{figs/analytic_birthwgt_model.pdf}}
-\caption{CDF of birth weights with a normal model.}
+\caption{CDF of birth weights with a normal model.}%
 \label{analytic_birthwgt_model}
 \end{figure}
 
 The normal distribution is a good model for this dataset, so
 if we summarize the distribution with the parameters
 $\mu = 7.28$ and $\sigma = 1.24$, the resulting error
-(difference between the model and the data) is small.
-\index{model}
+(difference between the model and the data) is small.%
+\index{model}%
 \index{percentile}
 
 Below the 10th percentile there is a discrepancy between the data
@@ -3602,9 +3633,9 @@ model.
 
 For the exponential distribution, and a few others, there are
 simple transformations we can use to test whether an analytic
-distribution is a good model for a dataset.
-\index{exponential distribution}
-\index{distribution!exponential}
+distribution is a good model for a dataset.%
+\index{exponential distribution}%
+\index{distribution!exponential}%
 \index{model}
 
 For the normal distribution there is no such transformation, but there
@@ -3612,12 +3643,12 @@ is an alternative called a {\bf normal probability plot}.  There
 are two ways to generate a normal probability plot: the hard way
 and the easy way.  If you are interested in the hard way, you can
 read about it at \url{https://en.wikipedia.org/wiki/Normal_probability_plot}.
-Here's the easy way:
-\index{normal probability plot}
-\index{plot!normal probability}
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
+Here's the easy way:%
+\index{normal probability plot}%
+\index{plot!normal probability}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
 \index{distribution!Gaussian}
 
 \begin{enumerate}
@@ -3625,7 +3656,7 @@ Here's the easy way:
 \item Sort the values in the sample.
 
 \item From a standard normal distribution ($\mu=0$ and $\sigma=1$),
-generate a random sample with the same size as the sample, and sort it.
+generate a random sample with the same size as the sample, and sort it.%
 \index{random number}
 
 \item Plot the sorted values from the sample versus the random values.
@@ -3635,7 +3666,7 @@ generate a random sample with the same size as the sample, and sort it.
 If the distribution of the sample is approximately normal, the result
 is a straight line with intercept {\tt mu} and slope {\tt sigma}.
 {\tt thinkstats2} provides {\tt NormalProbability}, which takes a
-sample and returns two NumPy arrays:
+sample and returns two NumPy arrays:%
 \index{NumPy}
 
 \begin{verbatim}
@@ -3645,7 +3676,7 @@ xs, ys = thinkstats2.NormalProbability(sample)
 \begin{figure}
 % analytic.py
 \centerline{\includegraphics[height=2.5in]{figs/analytic_normal_prob_example.pdf}}
-\caption{Normal probability plot for random samples from normal distributions.}
+\caption{Normal probability plot for random samples from normal distributions.}%
 \label{analytic_normal_prob_example}
 \end{figure}
 
@@ -3661,8 +3692,8 @@ deviating more than values near the mean.
 Now let's try it with real data.  Here's code to generate
 a normal probability plot for the birth weight data from the
 previous section.  It plots a gray line that represents the model
-and a blue line that represents the data.
-\index{birth weight}
+and a blue line that represents the data.%
+\index{birth weight}%
 \index{weight!birth}
 
 \begin{verbatim}
@@ -3679,10 +3710,10 @@ def MakeNormalPlot(weights):
 \end{verbatim}
 
 {\tt weights} is a pandas Series of birth weights;
-{\tt mean} and {\tt std} are the mean and standard deviation.
-\index{pandas}
-\index{Series}
-\index{thinkplot}
+{\tt mean} and {\tt std} are the mean and standard deviation.%
+\index{pandas}%
+\index{Series}%
+\index{thinkplot}%
 \index{standard deviation}
 
 {\tt FitLine} takes a sequence of {\tt xs}, an intercept, and a
@@ -3692,13 +3723,13 @@ with the given parameters, evaluated at the values in {\tt xs}.
 {\tt NormalProbability} returns {\tt xs} and {\tt ys} that
 contain values from the standard normal distribution and values
 from {\tt weights}.  If the distribution of weights is normal,
-the data should match the model.
+the data should match the model.%
 \index{model}
 
 \begin{figure}
 % analytic.py
 \centerline{\includegraphics[height=2.5in]{figs/analytic_birthwgt_normal.pdf}}
-\caption{Normal probability plot of birth weights.}
+\caption{Normal probability plot of birth weights.}%
 \label{analytic_birthwgt_normal}
 \end{figure}
 
@@ -3706,7 +3737,7 @@ Figure~\ref{analytic_birthwgt_normal} shows the results for
 all live births, and also for full term births (pregnancy length greater
 than 36 weeks).  Both curves match the model near the mean and
 deviate in the tails.  The heaviest babies are heavier than what
-the model expects, and the lightest babies are lighter.
+the model expects, and the lightest babies are lighter.%
 \index{pregnancy length}
 
 When we select only full term births, we remove some of the lightest
@@ -3716,15 +3747,15 @@ distribution.
 This plot suggests that the normal model describes the distribution
 well within a few standard deviations from the mean, but not in the
 tails.  Whether it is good enough for practical purposes depends
-on the purposes.
-\index{model}
-\index{birth weight}
-\index{weight!birth}
+on the purposes.%
+\index{model}%
+\index{birth weight}%
+\index{weight!birth}%
 \index{standard deviation}
 
 
-\section{The lognormal distribution}
-\label{brfss}
+\section{The lognormal distribution}%
+\label{brfss}%
 \label{lognormal}
 
 If the logarithms of a set of values have a normal distribution, the
@@ -3738,10 +3769,12 @@ The parameters of the lognormal distribution are usually denoted
 $\mu$ and $\sigma$.  But remember that these parameters are {\em not\/}
 the mean and standard deviation; the mean of a lognormal distribution
 is $\exp(\mu +\sigma^2/2)$ and the standard deviation is
-ugly (see \url{http://wikipedia.org/wiki/Log-normal_distribution}).
-\index{parameter} \index{weight!adult} \index{adult weight}
-\index{lognormal distribution}
-\index{distribution!lognormal}
+ugly (see \url{http://wikipedia.org/wiki/Log-normal_distribution}).%
+\index{parameter}%
+\index{weight!adult}%
+\index{adult weight}%
+\index{lognormal distribution}%
+\index{distribution!lognormal}%
 \index{CDF}
 
 \begin{figure}
@@ -3749,7 +3782,7 @@ ugly (see \url{http://wikipedia.org/wiki/Log-normal_distribution}).
 \centerline{
 \includegraphics[height=2.5in]{figs/brfss_weight.pdf}}
 \caption{CDF of adult weights on a linear scale (left) and
-log scale (right).}
+log scale (right).}%
 \label{brfss_weight}
 \end{figure}
 
@@ -3757,8 +3790,8 @@ If a sample is approximately lognormal and you plot its CDF on a
 log-x scale, it will have the characteristic shape of a normal
 distribution.  To test how well the sample fits a lognormal model, you
 can make a normal probability plot using the log of the values
-in the sample.
-\index{normal probability plot}
+in the sample.%
+\index{normal probability plot}%
 \index{model}
 
 As an example, let's look at the distribution of adult weights, which
@@ -3781,8 +3814,8 @@ the Behavioral Risk Factor Surveillance System
 2008, they interviewed 414,509 respondents and asked about their
 demographics, health, and health risks.
 Among the data they collected are the weights in kilograms of
-398,484 respondents.
-\index{Behavioral Risk Factor Surveillance System}
+398,484 respondents.%
+\index{Behavioral Risk Factor Surveillance System}%
 \index{BRFSS}
 
 The repository for this book contains {\tt CDBRFS08.ASC.gz},
@@ -3794,7 +3827,7 @@ and {\tt brfss.py}, which reads the file and analyzes the data.
 \centerline{
 \includegraphics[height=2.5in]{figs/brfss_weight_normal.pdf}}
 \caption{Normal probability plots for adult weight on a linear scale
-  (left) and log scale (right).}
+  (left) and log scale (right).}%
 \label{brfss_weight_normal}
 \end{figure}
 
@@ -3803,22 +3836,30 @@ weights on a linear scale with a normal model.
 Figure~\ref{brfss_weight} (right) shows the same distribution on a log
 scale with a lognormal model.  The lognormal model is a better fit,
 but this representation of the data does not make the difference
-particularly dramatic.  \index{respondent} \index{model}
+particularly dramatic.%
+\index{respondent}%
+\index{model}
 
 Figure~\ref{brfss_weight_normal} shows normal probability plots for
 adult weights, $w$, and for their logarithms, $\log_{10} w$.  Now it
 is apparent that the data deviate substantially from the normal model.
-On the other hand, the lognormal model is a good match for the data.
-\index{normal distribution} \index{distribution!normal}
-\index{Gaussian distribution} \index{distribution!Gaussian}
-\index{lognormal distribution} \index{distribution!lognormal}
-\index{standard deviation} \index{adult weight} \index{weight!adult}
-\index{model} \index{normal probability plot}
+On the other hand, the lognormal model is a good match for the data.%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
+\index{distribution!Gaussian}%
+\index{lognormal distribution}%
+\index{distribution!lognormal}%
+\index{standard deviation}%
+\index{adult weight}%
+\index{weight!adult}%
+\index{model}%
+\index{normal probability plot}
 
 
-\section{The Pareto distribution}
-\index{Pareto distribution}
-\index{distribution!Pareto}
+\section{The Pareto distribution}%
+\index{Pareto distribution}%
+\index{distribution!Pareto}%
 \index{Pareto, Vilfredo}
 
 The {\bf Pareto distribution} is named after the economist Vilfredo Pareto,
@@ -3826,7 +3867,8 @@ who used it to describe the distribution of wealth (see
 \url{http://wikipedia.org/wiki/Pareto_distribution}).  Since then, it
 has been used to describe phenomena in the natural and social sciences
 including sizes of cities and towns, sand particles and meteorites,
-forest fires and earthquakes.  \index{CDF}
+forest fires and earthquakes.%
+\index{CDF}
 
 The CDF of the Pareto distribution is:
 %
@@ -3836,13 +3878,13 @@ The parameters $x_{m}$ and $\alpha$ determine the location and shape
 of the distribution. $x_{m}$ is the minimum possible value.
 Figure~\ref{analytic_pareto_cdf} shows CDFs of Pareto
 distributions with $x_{m} = 0.5$ and different values
-of $\alpha$.
+of $\alpha$.%
 \index{parameter}
 
 \begin{figure}
 % analytic.py
 \centerline{\includegraphics[height=2.5in]{figs/analytic_pareto_cdf.pdf}}
-\caption{CDFs of Pareto distributions with different parameters.}
+\caption{CDFs of Pareto distributions with different parameters.}%
 \label{analytic_pareto_cdf}
 \end{figure}
 
@@ -3865,14 +3907,17 @@ $\alpha \log x_{m}$.
 
 As an example, let's look at the sizes of cities and towns.
 The U.S.~Census Bureau publishes the
-population of every incorporated city and town in the United States.
-\index{Pareto distribution} \index{distribution!Pareto}
-\index{U.S.~Census Bureau} \index{population} \index{city size}
+population of every incorporated city and town in the United States.%
+\index{Pareto distribution}%
+\index{distribution!Pareto}%
+\index{U.S.~Census Bureau}%
+\index{population}%
+\index{city size}
 
 \begin{figure}
 % populations.py
 \centerline{\includegraphics[height=2.5in]{figs/populations_pareto.pdf}}
-\caption{CCDFs of city and town populations, on a log-log scale.}
+\caption{CCDFs of city and town populations, on a log-log scale.}%
 \label{populations_pareto}
 \end{figure}
 
@@ -3887,13 +3932,13 @@ Figure~\ref{populations_pareto} shows the CCDF of populations on a
 log-log scale.  The largest 1\% of cities and towns, below $10^{-2}$,
 fall along a straight line.  So we could
 conclude, as some researchers have, that the tail of this distribution
-fits a Pareto model.
+fits a Pareto model.%
 \index{model}
 
 On the other hand, a lognormal distribution also models the data well.
 Figure~\ref{populations_normal} shows the CDF of populations and a
 lognormal model (left), and a normal probability plot (right).  Both
-plots show good agreement between the data and the model.
+plots show good agreement between the data and the model.%
 \index{normal probability plot}
 
 Neither model is perfect.
@@ -3907,18 +3952,18 @@ is relevant.
 % populations.py
 \centerline{\includegraphics[height=2.5in]{figs/populations_normal.pdf}}
 \caption{CDF of city and town populations on a log-x scale (left), and
-normal probability plot of log-transformed populations (right).}
+normal probability plot of log-transformed populations (right).}%
 \label{populations_normal}
 \end{figure}
 
 
-\section{Generating random numbers}
-\index{exponential distribution}
-\index{distribution!exponential}
-\index{random number}
-\index{CDF}
-\index{inverse CDF algorithm}
-\index{uniform distribution}
+\section{Generating random numbers}%
+\index{exponential distribution}%
+\index{distribution!exponential}%
+\index{random number}%
+\index{CDF}%
+\index{inverse CDF algorithm}%
+\index{uniform distribution}%
 \index{distribution!uniform}
 
 Analytic CDFs can be used to generate random numbers with a given
@@ -3926,8 +3971,8 @@ distribution function, $p = \CDF(x)$.  If there is an efficient way to
 compute the inverse CDF, we can generate random values
 with the appropriate distribution by choosing $p$ from a uniform
 distribution between 0 and 1, then choosing
-$x = ICDF(p)$.
-\index{inverse CDF}
+$x = ICDF(p)$.%
+\index{inverse CDF}%
 \index{CDF, inverse}
 
 For example, the CDF of the exponential distribution is
@@ -3955,27 +4000,29 @@ I called the parameter \verb"lam" because \verb"lambda" is a Python
 keyword.  Also, since $\log 0$ is undefined, we have to
 be a little careful.  The implementation of {\tt random.random}
 can return 0 but not 1, so $1 - p$ can be 1 but not 0, so
-{\tt log(1-p)} is always defined.  \index{random module}
+{\tt log(1-p)} is always defined.%
+\index{random module}
 
 
-\section{Why model?}
+\section{Why model?}%
 \index{model}
 
 At the beginning of this chapter, I said that many real world phenomena
 can be modeled with analytic distributions.  ``So,'' you might ask,
-``what?''  \index{abstraction}
+``what?''%
+\index{abstraction}
 
 Like all models, analytic distributions are abstractions, which
 means they leave out details that are considered irrelevant.
 For example, an observed distribution might have measurement errors
 or quirks that are specific to the sample; analytic models smooth
-out these idiosyncrasies.
+out these idiosyncrasies.%
 \index{smoothing}
 
 Analytic models are also a form of data compression.  When a model
 fits a dataset well, a small set of parameters can summarize a
-large amount of data.
-\index{parameter}
+large amount of data.%
+\index{parameter}%
 \index{compression}
 
 It is sometimes surprising when data from a natural phenomenon fit an
@@ -3984,11 +4031,11 @@ into physical systems.  Sometimes we can explain why an observed
 distribution has a particular form.  For example, Pareto distributions
 are often the result of generative processes with positive feedback
 (so-called preferential attachment processes: see
-\url{http://wikipedia.org/wiki/Preferential_attachment}.).
-\index{preferential attachment}
-\index{generative process}
-\index{Pareto distribution}
-\index{distribution!Pareto}
+\url{http://wikipedia.org/wiki/Preferential_attachment}.).%
+\index{preferential attachment}%
+\index{generative process}%
+\index{Pareto distribution}%
+\index{distribution!Pareto}%
 \index{analysis}
 
 Also, analytic distributions lend themselves to mathematical
@@ -4017,19 +4064,19 @@ My solution is in \verb"chap05soln.ipynb".
 In the BRFSS (see Section~\ref{lognormal}), the distribution of
 heights is roughly normal with parameters $\mu = 178$ cm and
 $\sigma = 7.7$ cm for men, and $\mu = 163$ cm and $\sigma = 7.3$ cm for
-women.
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
-\index{distribution!Gaussian}
-\index{height}
-\index{Blue Man Group}
+women.%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
+\index{distribution!Gaussian}%
+\index{height}%
+\index{Blue Man Group}%
 \index{Group, Blue Man}
 
 In order to join Blue Man Group, you have to be male between 5'10''
 and 6'1'' (see \url{http://bluemancasting.com}).  What percentage of
 the U.S. male population is in this range?  Hint: use {\tt
-  scipy.stats.norm.cdf}.
+  scipy.stats.norm.cdf}.%
 \index{SciPy}
 
 \end{exercise}
@@ -4041,21 +4088,21 @@ the world
 would be if the distribution of human height were Pareto.
 With the parameters $x_{m} = 1$ m and $\alpha = 1.7$, we
 get a distribution with a reasonable minimum, 1 m,
-and median, 1.5 m.
-\index{height}
-\index{Pareto distribution}
+and median, 1.5 m.%
+\index{height}%
+\index{Pareto distribution}%
 \index{distribution!Pareto}
 
 Plot this distribution.  What is the mean human height in Pareto
 world?  What fraction of the population is shorter than the mean?  If
 there are 7 billion people in Pareto world, how many do we expect to
-be taller than 1 km?  How tall do we expect the tallest person to be?
+be taller than 1 km?  How tall do we expect the tallest person to be?%
 \index{Pareto World}
 
 \end{exercise}
 
 
-\begin{exercise}
+\begin{exercise}%
 \label{weibull}
 
 The Weibull distribution is a generalization of the exponential
@@ -4066,11 +4113,11 @@ distribution that comes up in failure analysis
 %
 Can you find a transformation that makes a Weibull distribution look
 like a straight line?  What do the slope and intercept of the
-line indicate?
-\index{Weibull distribution}
-\index{distribution!Weibull}
-\index{exponential distribution}
-\index{distribution!exponential}
+line indicate?%
+\index{Weibull distribution}%
+\index{distribution!Weibull}%
+\index{exponential distribution}%
+\index{distribution!exponential}%
 \index{random module}
 
 Use {\tt random.weibullvariate} to generate a sample from a
@@ -4083,9 +4130,9 @@ Weibull distribution and use it to test your transformation.
 For small values of $n$, we don't expect an empirical distribution
 to fit an analytic distribution exactly.  One way to evaluate
 the quality of fit is to generate a sample from an analytic
-distribution and see how well it matches the data.
-\index{empirical distribution}
-\index{distribution!empirical}
+distribution and see how well it matches the data.%
+\index{empirical distribution}%
+\index{distribution!empirical}%
 \index{random module}
 
 For example, in Section~\ref{exponential} we plotted the distribution
@@ -4105,7 +4152,7 @@ to generate the values.
 In the repository for this book, you'll find a set of data files
 called {\tt mystery0.dat}, {\tt mystery1.dat}, and so on.  Each
 contains a sequence of random numbers generated from an analytic
-distribution.
+distribution.%
 \index{random number}
 
 You will also find \verb"test_models.py", a script that reads
@@ -4124,15 +4171,15 @@ the files.
 \end{exercise}
 
 
-\begin{exercise}
+\begin{exercise}%
 \label{income}
 
 The distributions of wealth and income are sometimes modeled using
 lognormal and Pareto distributions.  To see which is better, let's
-look at some data.
-\index{Pareto distribution}
-\index{distribution!Pareto}
-\index{lognormal distribution}
+look at some data.%
+\index{Pareto distribution}%
+\index{distribution!Pareto}%
+\index{lognormal distribution}%
 \index{distribution!lognormal}
 
 The Current Population Survey (CPS) is a joint effort of the Bureau
@@ -4146,7 +4193,7 @@ will also find {\tt hinc.py}, which reads this file.
 
 Extract the distribution of incomes from this dataset.  Are any of the
 analytic distributions in this chapter a good model of the data?  A
-solution to this exercise is in \url{hinc_soln.py}.
+solution to this exercise is in \url{hinc_soln.py}.%
 \index{model}
 
 \end{exercise}
@@ -4158,48 +4205,51 @@ solution to this exercise is in \url{hinc_soln.py}.
 
 \begin{itemize}
 
-\item empirical distribution: The distribution of values in a sample.
-  \index{empirical distribution} \index{distribution!empirical}
+\item empirical distribution: The distribution of values in a sample.%
+\index{empirical distribution}%
+\index{distribution!empirical}
 
 \item analytic distribution: A distribution whose CDF is an analytic
-function.
-\index{analytic distribution}
+function.%
+\index{analytic distribution}%
 \index{distribution!analytic}
 
 \item model: A useful simplification.  Analytic distributions are
-often good models of more complex empirical distributions.
+often good models of more complex empirical distributions.%
 \index{model}
 
-\item interarrival time: The elapsed time between two events.
+\item interarrival time: The elapsed time between two events.%
 \index{interarrival time}
 
 \item complementary CDF: A function that maps from a value, $x$,
-to the fraction of values that exceed $x$, which is $1 - \CDF(x)$.
-\index{complementary CDF} \index{CDF!complementary} \index{CCDF}
+to the fraction of values that exceed $x$, which is $1 - \CDF(x)$.%
+\index{complementary CDF}%
+\index{CDF!complementary}%
+\index{CCDF}
 
 \item standard normal distribution: The normal distribution with
-mean 0 and standard deviation 1.
+mean 0 and standard deviation 1.%
 \index{standard normal distribution}
 
 \item normal probability plot: A plot of the values in a sample versus
-random values from a standard normal distribution.
-\index{normal probability plot}
+random values from a standard normal distribution.%
+\index{normal probability plot}%
 \index{plot!normal probability}
 
 \end{itemize}
 
 
-\chapter{Probability density functions}
-\label{density}
-\index{PDF}
-\index{probability density function}
-\index{exponential distribution}
-\index{distribution!exponential}
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
-\index{distribution!Gaussian}
-\index{CDF}
+\chapter{Probability density functions}%
+\label{density}%
+\index{PDF}%
+\index{probability density function}%
+\index{exponential distribution}%
+\index{distribution!exponential}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
+\index{distribution!Gaussian}%
+\index{CDF}%
 \index{derivative}
 
 The code for this chapter is in {\tt density.py}.  For information
@@ -4220,8 +4270,8 @@ The PDF of a normal distribution is
                  \left( \frac{x - \mu}{\sigma} \right)^2 \right]  \]
 %
 Evaluating a PDF for a particular value of $x$ is usually not useful.
-The result is not a probability; it is a probability {\em density}.
-\index{density}
+The result is not a probability; it is a probability {\em density}.%
+\index{density}%
 \index{mass}
 
 In physics, density is mass per unit of
@@ -4246,7 +4296,7 @@ following methods:
 
 \item {\tt MakePmf}, which evaluates {\tt Density}
   at a discrete set of values and returns a normalized Pmf that
-  approximates the Pdf.
+  approximates the Pdf.%
 \index{Pmf}
 
 \item {\tt GetLinspace}, which returns the default set of points used 
@@ -4283,13 +4333,13 @@ The NormalPdf object contains the parameters {\tt mu} and
 {\tt sigma}.  {\tt Density} uses
 {\tt scipy.stats.norm}, which is an object that represents a normal
 distribution and provides {\tt cdf} and {\tt pdf}, among other
-methods (see Section~\ref{normal}).
+methods (see Section~\ref{normal}).%
 \index{SciPy}
 
 The following example creates a NormalPdf with the mean and variance
 of adult female heights, in cm, from the BRFSS (see
 Section~\ref{brfss}).  Then it computes the density of the
-distribution at a location one standard deviation from the mean.
+distribution at a location one standard deviation from the mean.%
 \index{standard deviation}
 
 \begin{verbatim}
@@ -4313,7 +4363,7 @@ we plot the Pdf, we can see the shape of the distribution:
 as contrasted with {\tt thinkplot.Pmf}, which renders a Pmf as a
 step function.  Figure~\ref{pdf_example} shows the result, as well
 as a PDF estimated from a sample, which we'll compute in the next
-section.
+section.%
 \index{thinkplot}
 
 You can use {\tt MakePmf} to approximate the Pdf:
@@ -4331,7 +4381,7 @@ and {\tt n}.
 % pdf_example.py
 \centerline{\includegraphics[height=2.2in]{figs/pdf_example.pdf}}
 \caption{A normal PDF that models adult female height in the U.S.,
-and the kernel density estimate of a sample with $n=500$.}
+and the kernel density estimate of a sample with $n=500$.}%
 \label{pdf_example}
 \end{figure}
 
@@ -4341,13 +4391,13 @@ and the kernel density estimate of a sample with $n=500$.}
 {\bf Kernel density estimation} (KDE) is an algorithm that takes
 a sample and finds an appropriately smooth PDF that fits 
 the data.  You can read details at
-\url{http://en.wikipedia.org/wiki/Kernel_density_estimation}.
-\index{KDE}
+\url{http://en.wikipedia.org/wiki/Kernel_density_estimation}.%
+\index{KDE}%
 \index{kernel density estimation}
 
 {\tt scipy} provides an implementation of KDE and {\tt thinkstats2}
-provides a class called {\tt EstimatedPdf} that uses it:
-\index{SciPy}
+provides a class called {\tt EstimatedPdf} that uses it:%
+\index{SciPy}%
 \index{NumPy}
 
 \begin{verbatim}
@@ -4368,11 +4418,12 @@ method.
 {\tt Density} takes a value or sequence, calls
 \verb"gaussian_kde.evaluate", and returns the resulting density.  The
 word ``Gaussian'' appears in the name because it uses a filter based
-on a Gaussian distribution to smooth the KDE.  \index{density}
+on a Gaussian distribution to smooth the KDE.%
+\index{density}
 
 Here's an example that generates a sample from a normal
-distribution and then makes an EstimatedPdf to fit it:
-\index{NumPy}
+distribution and then makes an EstimatedPdf to fit it:%
+\index{NumPy}%
 \index{EstimatedPdf}
 
 \begin{verbatim}
@@ -4383,8 +4434,8 @@ distribution and then makes an EstimatedPdf to fit it:
 
 \verb"sample" is a list of 500 random heights.
 \verb"sample_pdf" is a Pdf object that contains the estimated
-KDE of the sample.
-\index{thinkplot}
+KDE of the sample.%
+\index{thinkplot}%
 \index{Pmf}
 
 Figure~\ref{pdf_example} shows the normal density function and a KDE
@@ -4400,41 +4451,41 @@ Estimating a density function with KDE is useful for several purposes:
   look at a CDF, you can decide whether an estimated PDF is an
   appropriate model of the distribution.  If so, it can be a better
   choice for presenting the distribution to an audience that is
-  unfamiliar with CDFs.
-\index{visualization}
+  unfamiliar with CDFs.%
+\index{visualization}%
 \index{model}
 
 \item {\it Interpolation:\/} An estimated PDF is a way to get from a sample
   to a model of the population.  If you have reason to believe that
   the population distribution is smooth, you can use KDE to interpolate
-  the density for values that don't appear in the sample.
+  the density for values that don't appear in the sample.%
 \index{interpolation}
 
 \item {\it Simulation:\/} Simulations are often based on the distribution
   of a sample.  If the sample size is small, it
   might be appropriate to smooth the sample distribution using KDE,
   which allows the simulation to explore more possible outcomes,
-  rather than replicating the observed data.
+  rather than replicating the observed data.%
 \index{simulation}
 
 \end{itemize}
 
 
-\section{The distribution framework}
+\section{The distribution framework}%
 \index{distribution framework}
 
 \begin{figure}
 \centerline{\includegraphics[height=2.2in]{figs/distribution_functions.pdf}}
 \caption{A framework that relates representations of distribution
-functions.}
+functions.}%
 \label{dist_framework}
 \end{figure}
 
 At this point we have seen PMFs, CDFs and PDFs; let's take a minute
 to review.  Figure~\ref{dist_framework} shows how these functions relate
-to each other.
-\index{Pmf}
-\index{Cdf}
+to each other.%
+\index{Pmf}%
+\index{Cdf}%
 \index{Pdf}
 
 We started with PMFs, which represent the probabilities for a discrete
@@ -4442,39 +4493,41 @@ set of values.  To get from a PMF to a CDF, you add up the probability
 masses to get cumulative probabilities.  
 To get from a CDF back to a PMF, you compute differences in cumulative
 probabilities.  We'll see the implementation of these operations
-in the next few sections.
+in the next few sections.%
 \index{cumulative probability}
 
 A PDF is the derivative of a continuous CDF; or, equivalently,
 a CDF is the integral of a PDF.  Remember that a PDF maps from
 values to probability densities; to get a probability, you have to
-integrate.
-\index{discrete distribution}
-\index{continuous distribution}
+integrate.%
+\index{discrete distribution}%
+\index{continuous distribution}%
 \index{smoothing}
 
 To get from a discrete to a continuous distribution, you can perform
 various kinds of smoothing.  One form of smoothing is to assume that
 the data come from an analytic continuous distribution
 (like exponential or normal) and to estimate the parameters of that
-distribution.  Another option is kernel density estimation.
-\index{exponential distribution}
-\index{distribution!exponential}
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
+distribution.  Another option is kernel density estimation.%
+\index{exponential distribution}%
+\index{distribution!exponential}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
 \index{distribution!Gaussian}
 
 The opposite of smoothing is {\bf discretizing}, or quantizing.  If you
 evaluate a PDF at discrete points, you can generate a PMF that is an
 approximation of the PDF.  You can get a better approximation using
-numerical integration.  \index{discretize}
-\index{quantize}
+numerical integration.%
+\index{discretize}%
+\index{quantize}%
 \index{binning}
 
 To distinguish between continuous and discrete CDFs, it might be
 better for a discrete CDF to be a ``cumulative mass function,'' but as
-far as I can tell no one uses that term.  \index{CDF}
+far as I can tell no one uses that term.%
+\index{CDF}
 
 
 
@@ -4484,27 +4537,27 @@ At this point you should know how to use the basic types provided
 by {\tt thinkstats2}: Hist, Pmf, Cdf, and Pdf.  The next few sections
 provide details about how they are implemented.  This material
 might help you use these classes more effectively, but it is not
-strictly necessary.
+strictly necessary.%
 \index{Hist}
 
 Hist and Pmf inherit from a parent class called \verb"_DictWrapper".
 The leading underscore indicates that this class is ``internal;'' that
 is, it should not be used by code in other modules.  The name
 indicates what it is: a dictionary wrapper.  Its primary attribute is
-{\tt d}, the dictionary that maps from values to their frequencies.
-\index{DictWrapper}
-\index{internal class}
+{\tt d}, the dictionary that maps from values to their frequencies.%
+\index{DictWrapper}%
+\index{internal class}%
 \index{wrapper}
 
 The values can be any hashable type.  The frequencies should be integers,
-but can be any numeric type.
+but can be any numeric type.%
 \index{hashable}
 
 \verb"_DictWrapper" contains methods appropriate for both
 Hist and Pmf, including \verb"__init__", {\tt Values},
 {\tt Items} and {\tt Render}.  It also provides modifier
 methods {\tt Set}, {\tt Incr}, {\tt Mult}, and {\tt Remove}.  These
-methods are all implemented with dictionary operations.  For example:
+methods are all implemented with dictionary operations.  For example:%
 \index{dictionary}
 
 \begin{verbatim}
@@ -4521,12 +4574,12 @@ methods are all implemented with dictionary operations.  For example:
 \end{verbatim}
 
 Hist also provides {\tt Freq}, which looks up the frequency
-of a given value.
+of a given value.%
 \index{frequency}
 
 Because Hist operators and methods are based on dictionaries,
 these methods are constant time operations;
-that is, their run time does not increase as the Hist gets bigger.
+that is, their run time does not increase as the Hist gets bigger.%
 \index{Hist}
 
 
@@ -4534,7 +4587,7 @@ that is, their run time does not increase as the Hist gets bigger.
 
 Pmf and Hist are almost the same thing, except that a Pmf
 maps values to floating-point probabilities, rather than integer
-frequencies.  If the sum of the probabilities is 1, the Pmf is normalized.
+frequencies.  If the sum of the probabilities is 1, the Pmf is normalized.%
 \index{Pmf}
 
 Pmf provides {\tt Normalize}, which computes the sum of the
@@ -4562,7 +4615,7 @@ the Pmf cannot be normalized, so {\tt Normalize} raises {\tt
 
 Hist and Pmf have the same constructor.  It can take
 as an argument a {\tt dict}, Hist, Pmf or Cdf, a pandas
-Series, a list of (value, frequency) pairs, or a sequence of values.
+Series, a list of (value, frequency) pairs, or a sequence of values.%
 \index{Hist}
 
 If you instantiate a Pmf, the result is normalized.  If you
@@ -4579,12 +4632,12 @@ ordered and the values in a \verb"_DictWrapper" are not.  Also, it is
 often useful to compute the inverse CDF; that is, the map from
 cumulative probability to value.  So the implementaion I chose is two
 sorted lists.  That way I can use binary search to do a forward or
-inverse lookup in logarithmic time.
-\index{Cdf}
-\index{binary search}
-\index{cumulative probability}
-\index{DictWrapper}
-\index{inverse CDF}
+inverse lookup in logarithmic time.%
+\index{Cdf}%
+\index{binary search}%
+\index{cumulative probability}%
+\index{DictWrapper}%
+\index{inverse CDF}%
 \index{CDF, inverse}
 
 The Cdf constructor can take as a parameter a sequence of values
@@ -4608,7 +4661,7 @@ of corresponding frequencies.  {\tt np.cumsum} computes
 the cumulative sum of the frequencies.  Dividing through by the
 total frequency yields cumulative probabilities.
 For {\tt n} values, the time to construct the
-Cdf is proportional to $n \log n$.
+Cdf is proportional to $n \log n$.%
 \index{frequency}
 
 Here is the implementation of {\tt Prob}, which takes a value
@@ -4640,8 +4693,8 @@ cumulative probability and returns the corresponding value:
 
 Given a Cdf, we can compute the Pmf by computing differences between
 consecutive cumulative probabilities.  If you call the Cdf constructor
-and pass a Pmf, it computes differences by calling {\tt Cdf.Items}:
-\index{Pmf}
+and pass a Pmf, it computes differences by calling {\tt Cdf.Items}:%
+\index{Pmf}%
 \index{Cdf}
 
 \begin{verbatim}
@@ -4656,7 +4709,7 @@ and pass a Pmf, it computes differences by calling {\tt Cdf.Items}:
 {\tt np.roll} shifts the elements of {\tt a} to the right, and ``rolls''
 the last one back to the beginning.  We replace the first element of
 {\tt b} with 0 and then compute the difference {\tt a-b}.  The result
-is a NumPy array of probabilities.
+is a NumPy array of probabilities.%
 \index{NumPy}
 
 Cdf provides {\tt Shift} and {\tt Scale}, which modify the
@@ -4664,7 +4717,7 @@ values in the Cdf, but the probabilities should be treated as
 immutable.
 
 
-\section{Moments}
+\section{Moments}%
 \index{moment}
 
 Any time you take a sample and reduce it to a single number, that
@@ -4706,8 +4759,8 @@ why these statistics are called moments.  If we attach a weight along a
 ruler at each location, $x_i$, and then spin the ruler around
 the mean, the moment of inertia of the spinning weights is the variance
 of the values.  If you are not familiar with moment of inertia, see
-\url{http://en.wikipedia.org/wiki/Moment_of_inertia}.  \index{moment
-  of inertia}
+\url{http://en.wikipedia.org/wiki/Moment_of_inertia}.%
+\index{moment of inertia}
 
 When you report moment-based statistics, it is important to think
 about the units.  For example, if the values $x_i$ are in cm, the
@@ -4717,24 +4770,24 @@ cm$^2$, the third moment is in cm$^3$, and so on.
 Because of these units, moments are hard to interpret by themselves.
 That's why, for the second moment, it is common to report standard
 deviation, which is the square root of variance, so it is in the same
-units as $x_i$.
+units as $x_i$.%
 \index{standard deviation}
 
 
-\section{Skewness}
+\section{Skewness}%
 \index{skewness}
 
 {\bf Skewness} is a property that describes the shape of a distribution.
 If the distribution is symmetric around its central tendency, it is
 unskewed.  If the values extend farther to the right, it is ``right
-skewed'' and if the values extend left, it is ``left skewed.''
+skewed'' and if the values extend left, it is ``left skewed.''%
 \index{central tendency}
 
 This use of ``skewed'' does not have the usual connotation of
 ``biased.''  Skewness only describes the shape of the distribution;
 it says nothing about whether the sampling process might have been
-biased.
-\index{bias}
+biased.%
+\index{bias}%
 \index{sample skewness}
 
 Several statistics are commonly used to quantify the skewness of a
@@ -4752,7 +4805,7 @@ def Skewness(xs):
 \end{verbatim}
 
 $g_1$ is the third {\bf standardized moment}, which means that it has
-been normalized so it has no units.
+been normalized so it has no units.%
 \index{standardized moment}
 
 Negative skewness indicates that a distribution 
@@ -4763,15 +4816,15 @@ interpret.
 
 In practice, computing sample skewness is usually not
 a good idea.  If there are any outliers, they
-have a disproportionate effect on $g_1$.
+have a disproportionate effect on $g_1$.%
 \index{outlier}
 
 Another way to evaluate the asymmetry of a distribution is to look
 at the relationship between the mean and median.
 Extreme values have more effect on the mean than the median, so
 in a distribution that skews left, the mean is less than the median.
-In a distribution that skews right, the mean is greater.
-\index{symmetric}
+In a distribution that skews right, the mean is greater.%
+\index{symmetric}%
 \index{Pearson median skewness}
 
 {\bf Pearson's median skewness coefficient} is a measure
@@ -4781,7 +4834,7 @@ sample mean and median:
 \[ g_p = 3 (\xbar - m) / S \]
 %
 Where $\xbar$ is the sample mean, $m$ is the median, and
-$S$ is the standard deviation.  Or in Python:
+$S$ is the standard deviation.  Or in Python:%
 \index{standard deviation}
 
 \begin{verbatim}
@@ -4799,18 +4852,18 @@ def PearsonMedianSkewness(xs):
 \end{verbatim}
 
 This statistic is {\bf robust}, which means that it is less vulnerable
-to the effect of outliers.
-\index{robust}
+to the effect of outliers.%
+\index{robust}%
 \index{outlier}
 
 \begin{figure}
 \centerline{\includegraphics[height=2.2in]{figs/density_totalwgt_kde.pdf}}
-\caption{Estimated PDF of birthweight data from the NSFG.}
+\caption{Estimated PDF of birthweight data from the NSFG.}%
 \label{density_totalwgt_kde}
 \end{figure}
 
 As an example, let's look at the skewness of birth weights in the
-NSFG pregnancy data.  Here's the code to estimate and plot the PDF:
+NSFG pregnancy data.  Here's the code to estimate and plot the PDF:%
 \index{thinkplot}
 
 \begin{verbatim}
@@ -4826,19 +4879,19 @@ The mean, 7.27 lbs, is a bit less than
 the median, 7.38 lbs, so that is consistent with left skew.
 And both skewness coefficients are negative:
 sample skewness is -0.59;
-Pearson's median skewness is -0.23.
-\index{skewness}
-\index{dropna}
+Pearson's median skewness is -0.23.%
+\index{skewness}%
+\index{dropna}%
 \index{NaN}
 
 \begin{figure}
 \centerline{\includegraphics[height=2.2in]{figs/density_wtkg2_kde.pdf}}
-\caption{Estimated PDF of adult weight data from the BRFSS.}
+\caption{Estimated PDF of adult weight data from the BRFSS.}%
 \label{density_wtkg2_kde}
 \end{figure}
 
 Now let's compare this distribution to the distribution of adult
-weight in the BRFSS.  Again, here's the code:
+weight in the BRFSS.  Again, here's the code:%
 \index{thinkplot}
 
 \begin{verbatim}
@@ -4851,8 +4904,8 @@ weight in the BRFSS.  Again, here's the code:
 Figure~\ref{density_wtkg2_kde} shows the result.  The distribution
 appears skewed to the right.  Sure enough, the mean, 79.0, is bigger
 than the median, 77.3.  The sample skewness is 1.1 and Pearson's
-median skewness is 0.26.
-\index{dropna}
+median skewness is 0.26.%
+\index{dropna}%
 \index{NaN}
 
 The sign of the skewness coefficient indicates whether the distribution
@@ -4860,13 +4913,13 @@ skews left or right, but other than that, they are hard to interpret.
 Sample skewness is less robust; that is, it is more
 susceptible to outliers.  As a result it is less reliable
 when applied to skewed distributions, exactly when it would be most
-relevant.
-\index{outlier}
+relevant.%
+\index{outlier}%
 \index{robust}
 
 Pearson's median skewness is based on a computed mean and variance,
 so it is also susceptible to outliers, but since it does not depend
-on a third moment, it is somewhat more robust.
+on a third moment, it is somewhat more robust.%
 \index{Pearson median skewness}
 
 
@@ -4877,8 +4930,8 @@ A solution to this exercise is in \verb"chap06soln.py".
 \begin{exercise}
 
 The distribution of income is famously skewed to the right.  In this
-exercise, we'll measure how strong that skew is.
-\index{skewness}
+exercise, we'll measure how strong that skew is.%
+\index{skewness}%
 \index{income}
 
 The Current Population Survey (CPS) is a joint effort of the Bureau
@@ -4889,9 +4942,9 @@ I downloaded {\tt hinc06.xls}, which is an Excel spreadsheet with
 information about household income, and converted it to {\tt hinc06.csv},
 a CSV file you will find in the repository for this book.  You
 will also find {\tt hinc2.py}, which reads this file and transforms
-the data.
-\index{Current Population Survey}
-\index{Bureau of Labor Statistics}
+the data.%
+\index{Current Population Survey}%
+\index{Bureau of Labor Statistics}%
 \index{Census Bureau}
 
 The dataset is in the form of a series of income ranges and the number
@@ -4906,8 +4959,8 @@ the values are distributed in each range.  {\tt hinc2.py} provides
 {\tt InterpolateSample}, which shows one way to model
 this data.  It takes a DataFrame with a column, {\tt income}, that
 contains the upper bound of each range, and {\tt freq}, which contains
-the number of respondents in each frame.
-\index{DataFrame}
+the number of respondents in each frame.%
+\index{DataFrame}%
 \index{model}
 
 It also takes \verb"log_upper", which is an assumed upper bound
@@ -4933,49 +4986,49 @@ upper bound?
 \begin{itemize}
 
 \item Probability density function (PDF): The derivative of a continuous CDF,
-a function that maps a value to its probability density.
-\index{PDF}
+a function that maps a value to its probability density.%
+\index{PDF}%
 \index{probability density function}
 
 \item Probability density: A quantity that can be integrated over a
   range of values to yield a probability.  If the values are in units
   of cm, for example, probability density is in units of probability
-  per cm.
+  per cm.%
 \index{probability density}
 
 \item Kernel density estimation (KDE): An algorithm that estimates a PDF
-based on a sample.
-\index{kernel density estimation}
+based on a sample.%
+\index{kernel density estimation}%
 \index{KDE}
 
 \item discretize: To approximate a continuous function or distribution
-with a discrete function.  The opposite of smoothing.
+with a discrete function.  The opposite of smoothing.%
 \index{discretize}
 
-\item raw moment: A statistic based on the sum of data raised to a power.
+\item raw moment: A statistic based on the sum of data raised to a power.%
 \index{raw moment}
 
 \item central moment: A statistic based on deviation from the mean,
-raised to a power.
+raised to a power.%
 \index{central moment}
 
-\item standardized moment: A ratio of moments that has no units.
+\item standardized moment: A ratio of moments that has no units.%
 \index{standardized moment}
 
-\item skewness: A measure of how asymmetric a distribution is.
+\item skewness: A measure of how asymmetric a distribution is.%
 \index{skewness}
 
 \item sample skewness: A moment-based statistic intended to quantify
-the skewness of a distribution.
+the skewness of a distribution.%
 \index{sample skewness}
 
 \item Pearson's median skewness coefficient: A statistic intended to
   quantify the skewness of a distribution based on the median, mean,
-  and standard deviation.
-  \index{Pearson median skewness}
+  and standard deviation.%
+\index{Pearson median skewness}
 
 \item robust: A statistic is robust if it is relatively immune to the
-  effect of outliers.
+  effect of outliers.%
 \index{robust}
 
 \end{itemize}
@@ -4991,8 +5044,8 @@ example, height and weight are related; people who are taller tend to
 be heavier.  Of course, it is not a perfect relationship: there
 are short heavy people and tall light ones.  But if you are
 trying to guess someone's weight, you will be more accurate if you
-know their height than if you don't.
-\index{adult weight}
+know their height than if you don't.%
+\index{adult weight}%
 \index{adult height}
 
 The code for this chapter is in {\tt scatter.py}.
@@ -5000,14 +5053,14 @@ For information about downloading and
 working with this code, see Section~\ref{code}.
 
 
-\section{Scatter plots}
-\index{scatter plot}
+\section{Scatter plots}%
+\index{scatter plot}%
 \index{plot!scatter}
 
 The simplest way to check for a relationship between two variables
 is a {\bf scatter plot}, but making a good scatter plot is not always easy.
 As an example, I'll plot weight versus height for the respondents
-in the BRFSS (see Section~\ref{lognormal}).
+in the BRFSS (see Section~\ref{lognormal}).%
 \index{BRFSS}
 
 Here's the code that reads the data file and extracts height and
@@ -5019,7 +5072,7 @@ weight:
     heights, weights = sample.htm3, sample.wtkg2
 \end{verbatim}
 
-{\tt SampleRows} chooses a random subset of the data:
+{\tt SampleRows} chooses a random subset of the data:%
 \index{SampleRows}
 
 \begin{verbatim}
@@ -5032,10 +5085,10 @@ def SampleRows(df, nrows, replace=False):
 {\tt df} is the DataFrame, {\tt nrows} is the number of rows to choose,
 and {\tt replace} is a boolean indicating whether sampling should be
 done with replacement; in other words, whether the same row could be
-chosen more than once.
-\index{DataFrame}
-\index{thinkplot}
-\index{boolean}
+chosen more than once.%
+\index{DataFrame}%
+\index{thinkplot}%
+\index{boolean}%
 \index{replacement}
 
 {\tt thinkplot} provides {\tt Scatter}, which makes scatter plots:
@@ -5055,7 +5108,7 @@ people tend to be heavier.
 % scatter.py
 \centerline{\includegraphics[height=3.0in]{figs/scatter1.pdf}}
 \caption{Scatter plots of weight versus height for the respondents
-in the BRFSS, unjittered (left), jittered (right).}
+in the BRFSS, unjittered (left), jittered (right).}%
 \label{scatter1}
 \end{figure}
 
@@ -5063,15 +5116,18 @@ But this is not the best representation of
 the data, because the data are packed into columns.  The problem is
 that the heights are rounded to the nearest inch, converted to
 centimeters, and then rounded again.  Some information is lost in
-translation.  \index{height} \index{weight} \index{jitter}
+translation.%
+\index{height}%
+\index{weight}%
+\index{jitter}
 
 We can't get that information back, but we can minimize the effect on
 the scatter plot by {\bf jittering} the data, which means adding random
 noise to reverse the effect of rounding off.  Since these measurements
 were rounded to the nearest inch, they might be off by up to 0.5 inches or
-1.3 cm.  Similarly, the weights might be off by 0.5 kg.
-\index{uniform distribution}
-\index{distribution!uniform}
+1.3 cm.  Similarly, the weights might be off by 0.5 kg.%
+\index{uniform distribution}%
+\index{distribution!uniform}%
 \index{noise}
 
 %
@@ -5088,7 +5144,7 @@ def Jitter(values, jitter=0.5):
     return np.random.uniform(-jitter, +jitter, n) + values
 \end{verbatim}
 
-The values can be any sequence; the result is a NumPy array.
+The values can be any sequence; the result is a NumPy array.%
 \index{NumPy}
 
 Figure~\ref{scatter1} (right) shows the result.  Jittering reduces the
@@ -5099,15 +5155,15 @@ visualization and avoid using jittered data for analysis.
 Even with jittering, this is not the best way to represent the data.
 There are many overlapping points, which hides data
 in the dense parts of the figure and gives disproportionate emphasis
-to outliers.  This effect is called {\bf saturation}.
-\index{outlier}
+to outliers.  This effect is called {\bf saturation}.%
+\index{outlier}%
 \index{saturation}
 
 \begin{figure}
 % scatter.py
 \centerline{\includegraphics[height=3.0in]{figs/scatter2.pdf}}
 \caption{Scatter plot with jittering and transparency (left),
-hexbin plot (right).}
+hexbin plot (right).}%
 \label{scatter2}
 \end{figure}
 
@@ -5124,15 +5180,15 @@ version of the plot we can see two details that were not apparent before:
 vertical clusters at several heights and a horizontal line near 90 kg
 or 200 pounds.  Since this data is based on self-reports in pounds,
 the most likely explanation is that some respondents reported
-rounded values.
-\index{thinkplot}
-\index{alpha}
+rounded values.%
+\index{thinkplot}%
+\index{alpha}%
 \index{transparency}
 
 Using transparency works well for moderate-sized datasets, but this
 figure only shows the first 5000 records in the BRFSS, out of a total
-of 414 509.
-\index{hexbin plot}
+of 414 509.%
+\index{hexbin plot}%
 \index{plot!hexbin}
 
 To handle larger datasets, another option is a hexbin plot, which
@@ -5147,27 +5203,27 @@ how many data points fall in it.  {\tt thinkplot} provides
 Figure~\ref{scatter2} (right) shows the result.  An advantage of a
 hexbin is that it shows the shape of the relationship well, and it is
 efficient for large datasets, both in time and in the size of the file
-it generates.  A drawback is that it makes the outliers invisible.
-\index{thinkplot}
+it generates.  A drawback is that it makes the outliers invisible.%
+\index{thinkplot}%
 \index{outlier}
 
 The point of this example is that it is
 not easy to make a scatter plot that shows relationships clearly
-without introducing misleading artifacts.
+without introducing misleading artifacts.%
 \index{artifact}
 
 
-\section{Characterizing relationships}
+\section{Characterizing relationships}%
 \label{characterizing}
 
 Scatter plots provide a general impression of the relationship between
 variables, but there are other visualizations that provide more
 insight into the nature of the relationship.  One option is to bin one
-variable and plot percentiles of the other.
+variable and plot percentiles of the other.%
 \index{binning}
 
-NumPy and pandas provide functions for binning data:
-\index{NumPy}
+NumPy and pandas provide functions for binning data:%
+\index{NumPy}%
 \index{pandas}
 
 \begin{verbatim}
@@ -5179,9 +5235,9 @@ NumPy and pandas provide functions for binning data:
 
 {\tt dropna} drops rows with {\tt nan} in any of the listed columns.
 {\tt arange} makes a NumPy array of bins from 135 to, but not including,
-210, in increments of 5.
-\index{dropna}
-\index{digitize}
+210, in increments of 5.%
+\index{dropna}%
+\index{digitize}%
 \index{NaN}
 
 {\tt digitize} computes the index of the bin that contains each value
@@ -5192,15 +5248,15 @@ above the highest bin are mapped to {\tt len(bins)}.
 \begin{figure}
 % scatter.py
 \centerline{\includegraphics[height=2.5in]{figs/scatter3.pdf}}
-\caption{Percentiles of weight for a range of height bins.}
+\caption{Percentiles of weight for a range of height bins.}%
 \label{scatter3}
 \end{figure}
 
 {\tt groupby} is a DataFrame method that returns a GroupBy object;
 used in a {\tt for} loop, {\tt groups} iterates the names of the groups
 and the DataFrames that represent them.  So, for example, we can
-print the number of rows in each group like this:
-\index{DataFrame}
+print the number of rows in each group like this:%
+\index{DataFrame}%
 \index{groupby}
 
 \begin{verbatim}
@@ -5209,7 +5265,7 @@ for i, group in groups:
 \end{verbatim}
 
 Now for each group we can compute the mean height and the CDF
-of weight:
+of weight:%
 \index{Cdf}
 
 \begin{verbatim}
@@ -5218,7 +5274,7 @@ of weight:
 \end{verbatim}
 
 Finally, we can
-plot percentiles of weight versus height:
+plot percentiles of weight versus height:%
 \index{percentile}
 
 \begin{verbatim}
@@ -5231,19 +5287,19 @@ plot percentiles of weight versus height:
 Figure~\ref{scatter3} shows the result.  Between 140 and 200 cm
 the relationship between these variables is roughly linear.  This range
 includes more than 99\% of the data, so we don't have to worry
-too much about the extremes.
+too much about the extremes.%
 \index{thinkplot}
 
 
 \section{Correlation}
 
 A {\bf correlation} is a statistic intended to quantify the strength
-of the relationship between two variables.
+of the relationship between two variables.%
 \index{correlation}
 
 A challenge in measuring correlation is that the variables we want to
 compare are often not expressed in the same units.  And even if they
-are in the same units, they come from different distributions.
+are in the same units, they come from different distributions.%
 \index{units}
 
 There are two common solutions to these problems:
@@ -5253,50 +5309,51 @@ There are two common solutions to these problems:
 \item Transform each value to a {\bf standard score}, which is the
 number of standard deviations from the mean.  
 This transform leads to
-the ``Pearson product-moment correlation coefficient.''
-\index{standard score}
-\index{standard deviation}
+the ``Pearson product-moment correlation coefficient.''%
+\index{standard score}%
+\index{standard deviation}%
 \index{Pearson coefficient of correlation}
 
 \item Transform each value to its {\bf rank}, which is its index in
 the sorted list of values.  This transform
-leads to the ``Spearman rank correlation coefficient.''
-\index{rank}
-\index{percentile rank}
+leads to the ``Spearman rank correlation coefficient.''%
+\index{rank}%
+\index{percentile rank}%
 \index{Spearman coefficient of correlation}
 
 \end{enumerate}
 
 If $X$ is a series of $n$ values, $x_i$, we can convert to standard
 scores by subtracting the mean and dividing by the standard deviation:
-$z_i = (x_i - \mu) / \sigma$.
-\index{mean}
+$z_i = (x_i - \mu) / \sigma$.%
+\index{mean}%
 \index{standard deviation}
 
 The numerator is a deviation: the distance from the mean.  Dividing by
 $\sigma$ {\bf standardizes} the deviation, so the values of $Z$ are
 dimensionless (no units) and their distribution has mean 0 and
-variance 1.
-\index{standardize}
-\index{deviation}
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
+variance 1.%
+\index{standardize}%
+\index{deviation}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
 \index{distribution!Gaussian}
 
 If $X$ is normally distributed, so is $Z$.  But if $X$ is skewed or has
 outliers, so does $Z$; in those cases, it is more robust to use
 percentile ranks.  If we compute a new variable, $R$, so that $r_i$ is
 the rank of $x_i$, the distribution of $R$ is uniform
-from 1 to $n$, regardless of the distribution of $X$.
-\index{uniform distribution} \index{distribution!uniform}
-\index{robust}
-\index{skewness}
+from 1 to $n$, regardless of the distribution of $X$.%
+\index{uniform distribution}%
+\index{distribution!uniform}%
+\index{robust}%
+\index{skewness}%
 \index{outlier}
 
 
-\section{Covariance}
-\index{covariance}
+\section{Covariance}%
+\index{covariance}%
 \index{deviation}
 
 {\bf Covariance} is a measure of the tendency of two variables
@@ -5327,9 +5384,9 @@ If you have studied linear algebra, you might recognize that
 by their length.  So the covariance is maximized if the two vectors
 are identical, 0 if they are orthogonal, and negative if they
 point in opposite directions.  {\tt thinkstats2} uses {\tt np.dot} to
-implement {\tt Cov} efficiently:
-\index{linear algebra}
-\index{dot product}
+implement {\tt Cov} efficiently:%
+\index{linear algebra}%
+\index{dot product}%
 \index{orthogonal vector}
 
 \begin{verbatim}
@@ -5349,27 +5406,27 @@ def Cov(xs, ys, meanx=None, meany=None):
 By default {\tt Cov} computes deviations from the sample means,
 or you can provide known means.  If {\tt xs} and {\tt ys} are
 Python sequences, {\tt np.asarray} converts them to NumPy arrays.
-If they are already NumPy arrays, {\tt np.asarray} does nothing.
+If they are already NumPy arrays, {\tt np.asarray} does nothing.%
 \index{NumPy}
 
 This implementation of covariance is meant to be simple for purposes
 of explanation.  NumPy and pandas also provide implementations of
 covariance, but both of them apply a correction for small sample sizes
 that we have not covered yet, and {\tt np.cov} returns a covariance
-matrix, which is more than we need for now.
+matrix, which is more than we need for now.%
 \index{pandas}
 
 
-\section{Pearson's correlation}
-\index{correlation}
+\section{Pearson's correlation}%
+\index{correlation}%
 \index{standard score}
 
 Covariance is useful in some computations, but it is seldom reported
 as a summary statistic because it is hard to interpret.  Among other
 problems, its units are the product of the units of $X$ and $Y$.  For
 example, the covariance of weight and height in the BRFSS dataset is
-113 kilogram-centimeters, whatever that means.
-\index{deviation}
+113 kilogram-centimeters, whatever that means.%
+\index{deviation}%
 \index{units}
 
 One solution to this problem is to divide the deviations by the standard
@@ -5379,7 +5436,8 @@ standard scores:
 \[ p_i = \frac{(x_i - \xbar)}{S_X} \frac{(y_i - \ybar)}{S_Y} \]
 %
 Where $S_X$ and $S_Y$ are the standard deviations of $X$ and $Y$.
-The mean of these products is \index{standard deviation}
+The mean of these products is%
+\index{standard deviation}
 %
 \[ \rho = \frac{1}{n} \sum p_i \]
 %
@@ -5390,8 +5448,8 @@ $S_Y$:
 %
 This value is called {\bf Pearson's correlation} after Karl Pearson,
 an influential early statistician.  It is easy to compute and easy to
-interpret.  Because standard scores are dimensionless, so is $\rho$.
-\index{Pearson, Karl}
+interpret.  Because standard scores are dimensionless, so is $\rho$.%
+\index{Pearson, Karl}%
 \index{Pearson coefficient of correlation}
 
 Here is the implementation in {\tt thinkstats2}:
@@ -5409,7 +5467,7 @@ def Corr(xs, ys):
 \end{verbatim}
 
 {\tt MeanVar} computes mean and variance slightly more efficiently
-than separate calls to {\tt np.mean} and {\tt np.var}.
+than separate calls to {\tt np.mean} and {\tt np.var}.%
 \index{MeanVar}
 
 Pearson's correlation is always between -1 and +1 (including both).
@@ -5421,7 +5479,8 @@ when one variable is high, the other is low.
 The magnitude of $\rho$ indicates the strength of the correlation.  If
 $\rho$ is 1 or -1, the variables are perfectly correlated, which means
 that if you know one, you can make a perfect prediction about the
-other.  \index{prediction}
+other.%
+\index{prediction}
 
 Most correlation in the real world is not perfect, but it is still
 useful.  The correlation of height and weight is 0.51, which is a
@@ -5434,21 +5493,22 @@ If Pearson's correlation is near 0, it is tempting to conclude
 that there is no relationship between the variables, but that
 conclusion is not valid.  Pearson's correlation only measures {\em
   linear\/} relationships.  If there's a nonlinear relationship, $\rho$
-understates its strength.  \index{linear relationship}
-\index{nonlinear}
+understates its strength.%
+\index{linear relationship}%
+\index{nonlinear}%
 \index{Pearson coefficient of correlation}
 
 \begin{figure}
 \centerline{\includegraphics[height=2.5in]{figs/Correlation_examples.png}}
-\caption{Examples of datasets with a range of correlations.}
+\caption{Examples of datasets with a range of correlations.}%
 \label{corr_examples}
 \end{figure}
 
 Figure~\ref{corr_examples} is from
 \url{http://wikipedia.org/wiki/Correlation_and_dependence}.  It shows
 scatter plots and correlation coefficients for several
-carefully constructed datasets.
-\index{scatter plot}
+carefully constructed datasets.%
+\index{scatter plot}%
 \index{plot!scatter}
 
 The top row shows linear relationships with a range of correlations;
@@ -5457,11 +5517,11 @@ $\rho$ look like.  The second row shows perfect correlations with a
 range of slopes, which demonstrates that correlation is unrelated to
 slope (we'll talk about estimating slope soon).  The third row shows
 variables that are clearly related, but because the relationship is
-nonlinear, the correlation coefficient is 0.
+nonlinear, the correlation coefficient is 0.%
 \index{nonlinear}
 
 The moral of this story is that you should always look at a scatter
-plot of your data before blindly computing a correlation coefficient.
+plot of your data before blindly computing a correlation coefficient.%
 \index{correlation}
 
 
@@ -5469,22 +5529,22 @@ plot of your data before blindly computing a correlation coefficient.
 
 Pearson's correlation works well if the relationship between variables
 is linear and if the variables are roughly normal.  But it is not
-robust in the presence of outliers.
-\index{Pearson coefficient of correlation}
-\index{Spearman coefficient of correlation}
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
-\index{distribution!Gaussian}
+robust in the presence of outliers.%
+\index{Pearson coefficient of correlation}%
+\index{Spearman coefficient of correlation}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
+\index{distribution!Gaussian}%
 \index{robust}
 Spearman's rank correlation is an alternative that mitigates the
 effect of outliers and skewed distributions.  To compute Spearman's
 correlation, we have to compute the {\bf rank} of each value, which is its
 index in the sorted sample.  For example, in the sample {\tt [1, 2, 5, 7]}
 the rank of the value 5 is 3, because it appears third in the sorted
-list.  Then we compute Pearson's correlation for the ranks.
-\index{skewness}
-\index{outlier}
+list.  Then we compute Pearson's correlation for the ranks.%
+\index{skewness}%
+\index{outlier}%
 \index{rank}
 
 {\tt thinkstats2} provides a function that computes Spearman's rank
@@ -5500,8 +5560,8 @@ def SpearmanCorr(xs, ys):
 I convert the arguments to pandas Series objects so I can use
 {\tt rank}, which computes the rank for each value and returns
 a Series.  Then I use {\tt Corr} to compute the correlation
-of the ranks.
-\index{pandas}
+of the ranks.%
+\index{pandas}%
 \index{Series}
 
 I could also use {\tt Series.corr} directly and specify
@@ -5516,22 +5576,22 @@ def SpearmanCorr(xs, ys):
 
 The Spearman rank correlation for the BRFSS data is 0.54, a little
 higher than the Pearson correlation, 0.51.  There are several possible
-reasons for the difference, including:
-\index{rank correlation}
+reasons for the difference, including:%
+\index{rank correlation}%
 \index{BRFSS}
 
 \begin{itemize}
 
 \item If the relationship is
 nonlinear, Pearson's correlation tends to underestimate the strength
-of the relationship, and 
+of the relationship, and%
 \index{nonlinear}
 
 \item Pearson's correlation can be affected (in either direction)
 if one of the distributions is skewed or contains outliers.  Spearman's
-rank correlation is more robust.
-\index{skewness}
-\index{outlier}
+rank correlation is more robust.%
+\index{skewness}%
+\index{outlier}%
 \index{robust}
 
 \end{itemize}
@@ -5541,8 +5601,8 @@ roughly lognormal; under a log transform it approximates a normal
 distribution, so it has no skew.
 So another way to eliminate the effect of skewness is to
 compute Pearson's
-correlation with log-weight and height:
-\index{lognormal distribution}
+correlation with log-weight and height:%
+\index{lognormal distribution}%
 \index{distribution!lognormal}
 
 \begin{verbatim}
@@ -5551,20 +5611,20 @@ correlation with log-weight and height:
 
 The result is 0.53, close to the rank correlation, 0.54.  So that
 suggests that skewness in the distribution of weight explains most of
-the difference between Pearson's and Spearman's correlation.
-\index{skewness}
-\index{Spearman coefficient of correlation}
+the difference between Pearson's and Spearman's correlation.%
+\index{skewness}%
+\index{Spearman coefficient of correlation}%
 \index{Pearson coefficient of correlation}
 
 
-\section{Correlation and causation}
-\index{correlation}
+\section{Correlation and causation}%
+\index{correlation}%
 \index{causation}
 
 If variables A and B are correlated, there are three possible
 explanations: A causes B, or B causes A, or some other set of factors
 causes both A and B.  These explanations are called ``causal
-relationships''.
+relationships''.%
 \index{causal relationship}
 
 Correlation alone does not distinguish between these explanations,
@@ -5587,8 +5647,8 @@ So what can you do to provide evidence of causation?
   groups at random and compute the means of almost any variable, you
   expect the difference to be small.
   If the groups are nearly identical in all variables but one, you
-  can eliminate spurious relationships.
-  \index{spurious relationship}
+  can eliminate spurious relationships.%
+\index{spurious relationship}
 
   This works even if you don't know what the relevant variables
   are, but it works even better if you do, because you can check that
@@ -5600,11 +5660,11 @@ These ideas are the motivation for the {\bf randomized controlled
 trial}, in which subjects are assigned randomly to two (or more)
 groups: a {\bf treatment group} that receives some kind of intervention,
 like a new medicine, and a {\bf control group} that receives
-no intervention, or another treatment whose effects are known.
-\index{randomized controlled trial}
-\index{controlled trial}
-\index{treatment group}
-\index{control group}
+no intervention, or another treatment whose effects are known.%
+\index{randomized controlled trial}%
+\index{controlled trial}%
+\index{treatment group}%
+\index{control group}%
 \index{medicine}
 
 A randomized controlled trial is the most reliable way to demonstrate
@@ -5614,18 +5674,18 @@ a causal relationship, and the foundation of science-based medicine
 Unfortunately, controlled trials are only possible in the laboratory
 sciences, medicine, and a few other disciplines.  In the social sciences,
 controlled experiments are rare, usually because they are impossible
-or unethical.
+or unethical.%
 \index{ethics}
 
 An alternative is to look for a {\bf natural experiment}, where
 different ``treatments'' are applied to groups that are otherwise
 similar.  One danger of natural experiments is that the groups might
 differ in ways that are not apparent.  You can read more about this
-topic at \url{http://wikipedia.org/wiki/Natural_experiment}.
+topic at \url{http://wikipedia.org/wiki/Natural_experiment}.%
 \index{natural experiment}
 
 In some cases it is possible to infer causal relationships using {\bf
-  regression analysis}, which is the topic of Chapter~\ref{regression}.
+  regression analysis}, which is the topic of Chapter~\ref{regression}.%
 \index{regression analysis}
 
 
@@ -5638,10 +5698,10 @@ Using data from the NSFG, make a scatter plot of birth weight
 versus mother's age.  Plot percentiles of birth weight
 versus mother's age.  Compute Pearson's and Spearman's correlations.
 How would you characterize the relationship
-between these variables?
-\index{birth weight}
-\index{weight!birth}
-\index{Pearson coefficient of correlation}
+between these variables?%
+\index{birth weight}%
+\index{weight!birth}%
+\index{Pearson coefficient of correlation}%
 \index{Spearman coefficient of correlation}
 \end{exercise}
 
@@ -5651,53 +5711,53 @@ between these variables?
 \begin{itemize}
 
 \item scatter plot: A visualization of the relationship between
-two variables, showing one point for each row of data.
+two variables, showing one point for each row of data.%
 \index{scatter plot}
 
 \item jitter: Random noise added to data for purposes of
-visualization.
+visualization.%
 \index{jitter}
 
 \item saturation: Loss of information when multiple points are
-plotted on top of each other. 
+plotted on top of each other.%
 \index{saturation}
 
 \item correlation: A statistic that measures the strength of the
-relationship between two variables.
+relationship between two variables.%
 \index{correlation}
 
 \item standardize: To transform a set of values so that their mean is 0 and
-their variance is 1.
+their variance is 1.%
 \index{standardize}
 
 \item standard score: A value that has been standardized so that it is
-  expressed in standard deviations from the mean.
-  \index{standard score}
+  expressed in standard deviations from the mean.%
+\index{standard score}%
 \index{standard deviation}
 
 \item covariance: A measure of the tendency of two variables
-to vary together.
+to vary together.%
 \index{covariance}
 
-\item rank: The index where an element appears in a sorted list.
+\item rank: The index where an element appears in a sorted list.%
 \index{rank}
 
 \item randomized controlled trial: An experimental design in which subjects
 are divided into groups at random, and different groups are given different
-treatments.
+treatments.%
 \index{randomized controlled trial}
 
 \item treatment group: A group in a controlled trial that receives
-some kind of intervention.
+some kind of intervention.%
 \index{treatment group}
 
 \item control group: A group in a controlled trial that receives no
-treatment, or a treatment whose effect is known.
+treatment, or a treatment whose effect is known.%
 \index{control group}
 
 \item natural experiment: An experimental design that takes advantage of
 a natural division of subjects into groups in ways that are at least
-approximately random.
+approximately random.%
 \index{natural experiment}
 
 \end{itemize}
@@ -5705,8 +5765,8 @@ approximately random.
 
 
 
-\chapter{Estimation}
-\label{estimation}
+\chapter{Estimation}%
+\label{estimation}%
 \index{estimation}
 
 The code for this chapter is in {\tt estimation.py}.  For information
@@ -5717,54 +5777,54 @@ about downloading and working with this code, see Section~\ref{code}.
 
 Let's play a game.  I think of a distribution, and you have to guess
 what it is.  I'll give you two hints: it's a
-normal distribution, and here's a random sample drawn from it:
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
+normal distribution, and here's a random sample drawn from it:%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
 \index{distribution!Gaussian}
 
 {\tt [-0.441, 1.774, -0.101, -1.138, 2.975, -2.138]}
 
-What do you think is the mean parameter, $\mu$, of this distribution?
-\index{mean}
+What do you think is the mean parameter, $\mu$, of this distribution?%
+\index{mean}%
 \index{parameter}
 
 One choice is to use the sample mean, $\xbar$, as an estimate of $\mu$.
 In this example, $\xbar$ is 0.155, so it would
 be reasonable to guess $\mu$ = 0.155.
 This process is called {\bf estimation}, and the statistic we used
-(the sample mean) is called an {\bf estimator}.
+(the sample mean) is called an {\bf estimator}.%
 \index{estimator}
 
 Using the sample mean to estimate $\mu$ is so obvious that it is hard
 to imagine a reasonable alternative.  But suppose we change the game by
-introducing outliers.
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
+introducing outliers.%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
 \index{distribution!Gaussian}
 
 {\em I'm thinking of a distribution.\/}  It's a normal distribution, and
 here's a sample that was collected by an unreliable surveyor who
-occasionally puts the decimal point in the wrong place.
+occasionally puts the decimal point in the wrong place.%
 \index{measurement error}
 
 {\tt [-0.441, 1.774, -0.101, -1.138, 2.975, -213.8]}
 
 Now what's your estimate of $\mu$?  If you use the sample mean, your
-guess is -35.12.  Is that the best choice?  What are the alternatives?
+guess is -35.12.  Is that the best choice?  What are the alternatives?%
 \index{outlier}
 
 One option is to identify and discard outliers, then compute the sample
-mean of the rest.  Another option is to use the median as an estimator.
+mean of the rest.  Another option is to use the median as an estimator.%
 \index{median}
 
 Which estimator is best depends on the circumstances (for example,
 whether there are outliers) and on what the goal is.  Are you
 trying to minimize errors, or maximize your chance of getting the
-right answer?
-\index{error}
-\index{MSE}
+right answer?%
+\index{error}%
+\index{MSE}%
 \index{mean squared error}
 
 If there are no outliers, the sample mean minimizes the {\bf mean squared
@@ -5779,9 +5839,9 @@ compute $\xbar$.
 
 Here is a function that simulates the estimation game and computes
 the root mean squared error (RMSE), which is the square root of
-MSE:
-\index{mean squared error}
-\index{MSE}
+MSE:%
+\index{mean squared error}%
+\index{MSE}%
 \index{RMSE}
 
 \begin{verbatim}
@@ -5804,7 +5864,7 @@ def Estimate1(n=7, m=1000):
 
 Again, {\tt n} is the size of the sample, and {\tt m} is the
 number of times we play the game.  {\tt means} is the list of
-estimates based on $\xbar$.  {\tt medians} is the list of medians.
+estimates based on $\xbar$.  {\tt medians} is the list of medians.%
 \index{median}
 
 Here's the function that computes RMSE:
@@ -5820,7 +5880,7 @@ def RMSE(estimates, actual):
 actual value being estimated.  In practice, of course, we don't
 know {\tt actual}; if we did, we wouldn't have to estimate it.
 The purpose of this experiment is to compare the performance of
-the two estimators.
+the two estimators.%
 \index{estimator}
 
 When I ran this code, the RMSE of the sample mean was 0.41, which
@@ -5835,9 +5895,9 @@ strategy.  For example, suppose we are estimating the distribution of
 wind speeds at a building site.  If the estimate is too high, we might
 overbuild the structure, increasing its cost.  But if it's too
 low, the building might collapse.  Because cost as a function of
-error is not symmetric, minimizing MSE is not the best strategy.
-\index{prediction}
-\index{cost function}
+error is not symmetric, minimizing MSE is not the best strategy.%
+\index{prediction}%
+\index{cost function}%
 \index{MSE}
 
 As another example, suppose I roll three six-sided dice and ask you to
@@ -5847,16 +5907,17 @@ is 10.5, but that would be a bad guess, because the total of three
 dice is never 10.5.  For this game, you want an estimator that has the
 highest chance of being right, which is a {\bf maximum likelihood
   estimator} (MLE).  If you pick 10 or 11, your chance of winning is 1
-in 8, and that's the best you can do.  \index{MLE}
-\index{maximum likelihood estimator}
+in 8, and that's the best you can do.%
+\index{MLE}%
+\index{maximum likelihood estimator}%
 \index{dice}
 
 
-\section{Guess the variance}
-\index{variance}
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
+\section{Guess the variance}%
+\index{variance}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
 \index{distribution!Gaussian}
 
 {\em I'm thinking of a distribution\/.}  It's a normal distribution, and 
@@ -5874,11 +5935,11 @@ For large samples, $S^2$ is an adequate estimator, but for small
 samples it tends to be too low.  Because of this unfortunate
 property, it is called a {\bf biased} estimator.
 An estimator is {\bf unbiased} if the expected total (or mean) error,
-after many iterations of the estimation game, is 0.
-\index{sample variance}
-\index{biased estimator}
-\index{estimator!biased}
-\index{unbiased estimator}
+after many iterations of the estimation game, is 0.%
+\index{sample variance}%
+\index{biased estimator}%
+\index{estimator!biased}%
+\index{unbiased estimator}%
 \index{estimator!unbiased}
 
 Fortunately, there is another simple statistic that is an unbiased
@@ -5921,7 +5982,7 @@ we play the game.  {\tt np.var} computes $S^2$ by default and
 $S_{n-1}^2$ if you provide the argument {\tt ddof=1}, which stands for
 ``delta degrees of freedom.''  I won't explain that term, but you can read
 about it at
-\url{http://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)}.
+\url{http://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)}.%
 \index{degrees of freedom}
 
 {\tt MeanError} computes the mean difference between the estimates
@@ -5936,14 +5997,14 @@ def MeanError(estimates, actual):
 When I ran this code, the mean error for $S^2$ was -0.13.  As
 expected, this biased estimator tends to be too low.  For $S_{n-1}^2$,
 the mean error was 0.014, about 10 times smaller.  As {\tt m}
-increases, we expect the mean error for $S_{n-1}^2$ to approach 0.
+increases, we expect the mean error for $S_{n-1}^2$ to approach 0.%
 \index{mean error}
 
 Properties like MSE and bias are long-term expectations based on
 many iterations of the estimation game.  By running simulations like
 the ones in this chapter, we can compare estimators and check whether
-they have desired properties.
-\index{biased estimator}
+they have desired properties.%
+\index{biased estimator}%
 \index{estimator!biased}
 
 But when you apply an estimator to real
@@ -5957,7 +6018,7 @@ uncertainty of the estimate, which is the topic of the next
 section.
 
 
-\section{Sampling distributions}
+\section{Sampling distributions}%
 \label{gorilla}
 
 Suppose you are a scientist studying gorillas in a wildlife
@@ -5969,27 +6030,27 @@ information, it might be acceptable to weigh a sample of 9
 gorillas.  Let's assume that the population of the preserve is
 well known, so we can choose a representative sample of adult
 females.  We could use the sample mean, $\xbar$, to estimate the
-unknown population mean, $\mu$.
-\index{gorilla}
-\index{population}
+unknown population mean, $\mu$.%
+\index{gorilla}%
+\index{population}%
 \index{sample}
 
 Having weighed 9 female gorillas, you might find $\xbar=90$ kg and
 sample standard deviation, $S=7.5$ kg.  The sample mean
 is an unbiased estimator of $\mu$, and in the long run it
 minimizes MSE.  So if you report a single
-estimate that summarizes the results, you would report 90 kg.
-\index{MSE}
-\index{sample mean}
-\index{biased estimator}
-\index{estimator!biased}
+estimate that summarizes the results, you would report 90 kg.%
+\index{MSE}%
+\index{sample mean}%
+\index{biased estimator}%
+\index{estimator!biased}%
 \index{standard deviation}
 
 But how confident should you be in this estimate?  If you only weigh
 $n=9$ gorillas out of a much larger population, you might be unlucky
 and choose the 9 heaviest gorillas (or the 9 lightest ones) just by
 chance.  Variation in the estimate caused by random selection is
-called {\bf sampling error}.
+called {\bf sampling error}.%
 \index{sampling error}
 
 To quantify sampling error, we can simulate the
@@ -6022,15 +6083,15 @@ def SimulateSample(mu=90, sigma=7.5, n=9, m=1000):
 {\tt mu} and {\tt sigma} are the {\em hypothetical\/} values of
 the parameters.  {\tt n} is the sample size, the number of
 gorillas we measured.  {\tt m} is the number of times we run
-the simulation.
-\index{gorilla}
-\index{sample size}
+the simulation.%
+\index{gorilla}%
+\index{sample size}%
 \index{simulation}
 
 \begin{figure}
 % estimation.py
 \centerline{\includegraphics[height=2.5in]{figs/estimation1.pdf}}
-\caption{Sampling distribution of $\xbar$, with confidence interval.}
+\caption{Sampling distribution of $\xbar$, with confidence interval.}%
 \label{estimation1}
 \end{figure}
 
@@ -6040,7 +6101,7 @@ distribution with the given parameters, and compute the sample mean,
 distribution, {\tt cdf}, of the estimates.  The result is shown in
 Figure~\ref{estimation1}.  This distribution is called the {\bf
   sampling distribution} of the estimator.  It shows how much the
-estimates would vary if we ran the experiment over and over.
+estimates would vary if we ran the experiment over and over.%
 \index{sampling distribution}
 
 The mean of the sampling distribution is pretty close
@@ -6056,14 +6117,14 @@ There are two common ways to summarize the sampling distribution:
 \item {\bf Standard error} (SE) is a measure of how far we expect the
   estimate to be off, on average.  For each simulated experiment, we
   compute the error, $\xbar - \mu$, and then compute the root mean
-  squared error (RMSE).  In this example, it is roughly 2.5 kg.
+  squared error (RMSE).  In this example, it is roughly 2.5 kg.%
 \index{standard error}
 
 \item A {\bf confidence interval} (CI) is a range that includes a
   given fraction of the sampling distribution.  For example, the 90\%
   confidence interval is the range from the 5th to the 95th
-  percentile.  In this example, the 90\% CI is $(86, 94)$ kg.
-\index{confidence interval}
+  percentile.  In this example, the 90\% CI is $(86, 94)$ kg.%
+\index{confidence interval}%
 \index{sampling distribution}
 
 \end{itemize}
@@ -6077,8 +6138,8 @@ Standard errors and confidence intervals are the source of much confusion:
   quantity; in this example, the standard deviation of gorilla weight
   is 7.5 kg.  Standard error describes variability in an estimate.  In
   this example, the standard error of the mean, based on a sample of 9
-  measurements, is 2.5 kg.
-\index{gorilla}
+  measurements, is 2.5 kg.%
+\index{gorilla}%
 \index{standard deviation}
 
   One way to remember the difference is that, as sample size
@@ -6087,12 +6148,12 @@ Standard errors and confidence intervals are the source of much confusion:
 \item People often think that there is a 90\% probability that the
   actual parameter, $\mu$, falls in the 90\% confidence interval.
   Sadly, that is not true.  If you want to make a claim like that, you
-  have to use Bayesian methods (see my book, {\it Think Bayes\/}).
+  have to use Bayesian methods (see my book, {\it Think Bayes\/}).%
 \index{Bayesian statistics}
 
   The sampling distribution answers a different question: it gives you
   a sense of how reliable an estimate is by telling you how much it
-  would vary if you ran the experiment again.
+  would vary if you ran the experiment again.%
 \index{sampling distribution}
 
 \end{itemize}
@@ -6111,18 +6172,18 @@ Suppose that instead of the weight of gorillas in a nature preserve,
 you want to know the average weight of women in the city where you
 live.  It is unlikely that you would be allowed
 to choose a representative sample of women and
-weigh them.
-\index{gorilla}
-\index{adult weight}
-\index{sampling bias}
-\index{bias!sampling}
+weigh them.%
+\index{gorilla}%
+\index{adult weight}%
+\index{sampling bias}%
+\index{bias!sampling}%
 \index{measurement error}
 
 A simple alternative would be
 ``telephone sampling;'' that is,
 you could choose random numbers from the phone book, call and ask to
-speak to an adult woman, and ask how much she weighs.
-\index{telephone sampling}
+speak to an adult woman, and ask how much she weighs.%
+\index{telephone sampling}%
 \index{random number}
 
 Telephone sampling has obvious limitations.  For example, the sample
@@ -6137,33 +6198,33 @@ If factors like income, employment, and household size are related
 to weight---and it is plausible that they are---the results of your
 survey would be affected one way or another.  This problem is
 called {\bf sampling bias} because it is a property of the sampling
-process.
+process.%
 \index{sampling bias}
 
 This sampling process is also vulnerable to self-selection, which is a
 kind of sampling bias.  Some people will refuse to answer the
 question, and if the tendency to refuse is related to weight, that
-would affect the results.
+would affect the results.%
 \index{self-selection}
 
 Finally, if you ask people how much they weigh, rather than weighing
 them, the results might not be accurate.  Even helpful respondents
 might round up or down if they are uncomfortable with their actual
 weight.  And not all respondents are helpful.  These inaccuracies are
-examples of {\bf measurement error}.
+examples of {\bf measurement error}.%
 \index{measurement error}
 
 When you report an estimated quantity, it is useful to report
 standard error, or a confidence interval, or both, in order to
 quantify sampling error.  But it is also important to remember that
 sampling error is only one source of error, and often it is not the
-biggest.
-\index{standard error}
+biggest.%
+\index{standard error}%
 \index{confidence interval}
 
 
-\section{Exponential distributions}
-\index{exponential distribution}
+\section{Exponential distributions}%
+\index{exponential distribution}%
 \index{distribution!exponential}
 
 Let's play one more round of the estimation game.
@@ -6172,8 +6233,8 @@ here's a sample:
 
 {\tt [5.384, 4.493, 19.198, 2.790, 6.122, 12.844]}
 
-What do you think is the parameter, $\lambda$, of this distribution?
-\index{parameter}
+What do you think is the parameter, $\lambda$, of this distribution?%
+\index{parameter}%
 \index{mean}
 
 \newcommand{\lamhat}{L}
@@ -6189,14 +6250,14 @@ estimator of $\lambda$.  And not just any estimator; it is also the
 maximum likelihood estimator (see
 \url{http://wikipedia.org/wiki/Exponential_distribution#Maximum_likelihood}).
 So if you want to maximize your chance of guessing $\lambda$ exactly,
-$\lamhat$ is the way to go.
-\index{MLE}
+$\lamhat$ is the way to go.%
+\index{MLE}%
 \index{maximum likelihood estimator}
 
 But we know that $\xbar$ is not robust in the presence of outliers, so
-we expect $\lamhat$ to have the same problem.
-\index{robust}
-\index{outlier}
+we expect $\lamhat$ to have the same problem.%
+\index{robust}%
+\index{outlier}%
 \index{sample median}
 
 We can choose an alternative based on the sample median.
@@ -6205,7 +6266,7 @@ so working backwards again, we can define an estimator
 %
 \[ \lamhatmed = \ln(2) / m \]
 %
-where $m$ is the sample median.
+where $m$ is the sample median.%
 \index{median}
 
 To test the performance of these estimators, we can simulate the
@@ -6233,14 +6294,14 @@ def Estimate3(n=7, m=1000):
 When I run this experiment with $\lambda=2$, the RMSE of $L$ is
 1.1.  For the median-based estimator $L_m$, RMSE is 1.8.  We can't
 tell from this experiment whether $L$ minimizes MSE, but at least
-it seems better than $L_m$.
-\index{MSE}
+it seems better than $L_m$.%
+\index{MSE}%
 \index{RMSE}
 
 Sadly, it seems that both estimators are biased.  For $L$ the mean
 error is 0.33; for $L_m$ it is 0.45.  And neither converges to 0
-as {\tt m} increases.
-\index{biased estimator}
+as {\tt m} increases.%
+\index{biased estimator}%
 \index{estimator!biased}
 
 It turns out that $\xbar$ is an unbiased estimator of the mean
@@ -6262,9 +6323,9 @@ $S^2$ is biased and $S_{n-1}^2$ unbiased.
 
 Run similar experiments to see if $\xbar$ and median are biased estimates
 of $\mu$.
-Also check whether $S^2$ or $S_{n-1}^2$ yields a lower MSE.
-\index{sample mean}
-\index{sample median}
+Also check whether $S^2$ or $S_{n-1}^2$ yields a lower MSE.%
+\index{sample mean}%
+\index{sample median}%
 \index{estimator!biased}
 
 \end{exercise}
@@ -6276,14 +6337,14 @@ Suppose you draw a sample with size $n=10$ from
 an exponential distribution with $\lambda=2$.  Simulate
 this experiment 1000 times and plot the sampling distribution of
 the estimate $\lamhat$.  Compute the standard error of the estimate
-and the 90\% confidence interval.
-\index{standard error}
-\index{confidence interval}
+and the 90\% confidence interval.%
+\index{standard error}%
+\index{confidence interval}%
 \index{sampling distribution}
 
 Repeat the experiment with a few different values of $n$ and make
-a plot of standard error versus $n$.
-\index{exponential distribution}
+a plot of standard error versus $n$.%
+\index{exponential distribution}%
 \index{distribution!exponential}
 
 
@@ -6296,8 +6357,8 @@ In games like hockey and soccer, the time between goals is
 roughly exponential.  So you could estimate a team's goal-scoring rate
 by observing the number of goals they score in a game.  This
 estimation process is a little different from sampling the time
-between goals, so let's see how it works.
-\index{hockey}
+between goals, so let's see how it works.%
+\index{hockey}%
 \index{soccer}
 
 Write a function that takes a goal-scoring rate, {\tt lam}, in goals
@@ -6311,10 +6372,10 @@ estimates of {\tt lam}, then computes their mean error and RMSE.
 Is this way of making an estimate biased?  Plot the sampling
 distribution of the estimates and the 90\% confidence interval.  What
 is the standard error?  What happens to sampling error for increasing
-values of {\tt lam}?
-\index{estimator!biased}
-\index{biased estimator}
-\index{standard error}
+values of {\tt lam}?%
+\index{estimator!biased}%
+\index{biased estimator}%
+\index{standard error}%
 \index{confidence interval}
 
 \end{exercise}
@@ -6325,69 +6386,75 @@ values of {\tt lam}?
 \begin{itemize}
 
 \item estimation: The process of inferring the parameters of a distribution
-from a sample.
+from a sample.%
 \index{estimation}
 
-\item estimator: A statistic used to estimate a parameter.
+\item estimator: A statistic used to estimate a parameter.%
 \index{estimation}
 
-\item mean squared error (MSE): A measure of estimation error.
-\index{mean squared error}
+\item mean squared error (MSE): A measure of estimation error.%
+\index{mean squared error}%
 \index{MSE}
 
 \item root mean squared error (RMSE): The square root of MSE,
-a more meaningful representation of typical error magnitude.
-\index{mean squared error}
+a more meaningful representation of typical error magnitude.%
+\index{mean squared error}%
 \index{MSE}
 
 \item maximum likelihood estimator (MLE): An estimator that computes the
-point estimate most likely to be correct.
-\index{MLE}
+point estimate most likely to be correct.%
+\index{MLE}%
 \index{maximum likelihood estimator}
 
 \item bias (of an estimator): The tendency of an estimator to be above or
   below the actual value of the parameter, when averaged over repeated
-  experiments.  \index{biased estimator}
+  experiments.%
+\index{biased estimator}
 
 \item sampling error: Error in an estimate due to the limited
-  size of the sample and variation due to chance. \index{point estimation}
+  size of the sample and variation due to chance.%
+\index{point estimation}
 
 \item sampling bias: Error in an estimate due to a sampling process
-  that is not representative of the population. \index{sampling bias}
+  that is not representative of the population.%
+\index{sampling bias}
 
 \item measurement error: Error in an estimate due to inaccuracy collecting
-  or recording data. \index{measurement error}
+  or recording data.%
+\index{measurement error}
 
 \item sampling distribution: The distribution of a statistic if an
-  experiment is repeated many times.  \index{sampling distribution}
+  experiment is repeated many times.%
+\index{sampling distribution}
 
 \item standard error: The RMSE of an estimate,
 which quantifies variability due to sampling error (but not
-other sources of error).
+other sources of error).%
 \index{standard error}
 
 \item confidence interval: An interval that represents the expected
-  range of an estimator if an experiment is repeated many times.
-  \index{confidence interval} \index{interval!confidence}
+  range of an estimator if an experiment is repeated many times.%
+\index{confidence interval}%
+\index{interval!confidence}
 
 \end{itemize}
 
 
-\chapter{Hypothesis testing}
+\chapter{Hypothesis testing}%
 \label{testing}
 
 The code for this chapter is in {\tt hypothesis.py}.  For information
 about downloading and working with this code, see Section~\ref{code}.
 
-\section{Classical hypothesis testing}
-\index{hypothesis testing}
+\section{Classical hypothesis testing}%
+\index{hypothesis testing}%
 \index{apparent effect}
 
 Exploring the data from the NSFG, we saw several ``apparent effects,''
 including differences between first babies and others.
 So far we have taken these effects at face value; in this chapter,
-we put them to the test.
-\index{National Survey of Family Growth}
+we put them to the test.%
+\index{National Survey of Family Growth}%
 \index{NSFG}
 
 The fundamental question we want to address is whether the effects
@@ -6395,16 +6462,17 @@ we see in a sample are likely to appear in the larger population.
 For example, in the NSFG sample we see a difference in mean pregnancy
 length for first babies and others.  We would like to know if
 that effect reflects a real difference for women
-in the U.S., or if it might appear in the sample by chance.
-\index{pregnancy length} \index{length!pregnancy}
+in the U.S., or if it might appear in the sample by chance.%
+\index{pregnancy length}%
+\index{length!pregnancy}
 
 There are several ways we could formulate this question, including
 Fisher null hypothesis testing, Neyman-Pearson decision theory, and
 Bayesian inference\footnote{For more about Bayesian inference, see the
   sequel to this book, {\it Think Bayes}.}.  What I present here is a
 subset of all three that makes up most of what people use in practice,
-which I will call {\bf classical hypothesis testing}.
-\index{Bayesian inference}
+which I will call {\bf classical hypothesis testing}.%
+\index{Bayesian inference}%
 \index{null hypothesis}
 
 The goal of classical hypothesis testing is to answer the question,
@@ -6417,56 +6485,58 @@ seeing such an effect by chance?''  Here's how we answer that question:
   choosing a {\bf test statistic}.  In the NSFG example, the apparent
   effect is a difference in pregnancy length between first babies and
   others, so a natural choice for the test statistic is the difference
-  in means between the two groups.
-  \index{test statistic}
+  in means between the two groups.%
+\index{test statistic}
 
 \item The second step is to define a {\bf null hypothesis}, which is a
   model of the system based on the assumption that the apparent effect
   is not real.  In the NSFG example the null hypothesis is that there
   is no difference between first babies and others; that is, that
-  pregnancy lengths for both groups have the same distribution.
-  \index{null hypothesis}
-\index{pregnancy length}
+  pregnancy lengths for both groups have the same distribution.%
+\index{null hypothesis}%
+\index{pregnancy length}%
 \index{model}
 
 \item The third step is to compute a {\bf p-value}, which is the
   probability of seeing the apparent effect if the null hypothesis is
   true.  In the NSFG example, we would compute the actual difference
   in means, then compute the probability of seeing a
-  difference as big, or bigger, under the null hypothesis.
-  \index{p-value}
+  difference as big, or bigger, under the null hypothesis.%
+\index{p-value}
 
 \item The last step is to interpret the result.  If the p-value is
   low, the effect is said to be {\bf statistically significant}, which
   means that it is unlikely to have occurred by chance.  In that case
   we infer that the effect is more likely to appear in the larger
-  population.  \index{statistically significant} \index{significant}
+  population.%
+\index{statistically significant}%
+\index{significant}
 
 \end{itemize}
 
 The logic of this process is similar to a proof by
 contradiction.  To prove a mathematical statement, A, you assume
 temporarily that A is false.  If that assumption leads to a
-contradiction, you conclude that A must actually be true.
-\index{contradiction, proof by}
+contradiction, you conclude that A must actually be true.%
+\index{contradiction, proof by}%
 \index{proof by contradiction}
 
 Similarly, to test a hypothesis like, ``This effect is real,'' we
 assume, temporarily, that it is not.  That's the null hypothesis.
 Based on that assumption, we compute the probability of the apparent
 effect.  That's the p-value.  If the p-value is low, we
-conclude that the null hypothesis is unlikely to be true.
-\index{p-value}
+conclude that the null hypothesis is unlikely to be true.%
+\index{p-value}%
 \index{null hypothesis}
 
 
-\section{HypothesisTest}
-\label{hypotest}
+\section{HypothesisTest}%
+\label{hypotest}%
 \index{mean!difference in}
 
 {\tt thinkstats2} provides {\tt HypothesisTest}, a
 class that represents the structure of a classical hypothesis
-test.  Here is the definition:
+test.  Here is the definition:%
 \index{HypothesisTest}
 
 \begin{verbatim}
@@ -6498,14 +6568,14 @@ class HypothesisTest(object):
 complete definitions for some methods and place-keepers for others.
 Child classes based on {\tt HypothesisTest} inherit \verb"__init__"
 and {\tt PValue} and provide {\tt TestStatistic},
-{\tt RunModel}, and optionally {\tt MakeModel}.
+{\tt RunModel}, and optionally {\tt MakeModel}.%
 \index{HypothesisTest}
 
 \verb"__init__" takes the data in whatever form is appropriate.  It
 calls {\tt MakeModel}, which builds a representation of the null
 hypothesis, then passes the data to {\tt TestStatistic}, which
-computes the size of the effect in the sample.
-\index{test statistic}
+computes the size of the effect in the sample.%
+\index{test statistic}%
 \index{null hypothesis}
 
 {\tt PValue} computes the probability of the apparent effect under
@@ -6515,7 +6585,7 @@ data, computes test statistics, and stores them in
 \verb"test_stats".
 The result is
 the fraction of elements in \verb"test_stats" that
-exceed or equal the observed test statistic, {\tt self.actual}.
+exceed or equal the observed test statistic, {\tt self.actual}.%
 \index{simulation}
 
 As a simple example\footnote{Adapted from MacKay, {\it Information
@@ -6524,8 +6594,8 @@ toss a coin 250 times and see 140 heads and 110 tails.  Based on this
 result, we might suspect that the coin is biased; that is, more likely
 to land heads.  To test this hypothesis, we compute the
 probability of seeing such a difference if the coin is actually
-fair:
-\index{biased coin}
+fair:%
+\index{biased coin}%
 \index{MacKay, David}
 
 \begin{verbatim}
@@ -6548,14 +6618,14 @@ class CoinTest(thinkstats2.HypothesisTest):
 The parameter, {\tt data}, is a pair of
 integers: the number of heads and tails.  The test statistic is
 the absolute difference between them, so {\tt self.actual}
-is 30.
+is 30.%
 \index{HypothesisTest}
 
 {\tt RunModel} simulates coin tosses assuming that the coin is
 actually fair.  It generates a sample of 250 tosses, uses Hist
 to count the number of heads and tails, and returns a pair of
-integers.
-\index{Hist}
+integers.%
+\index{Hist}%
 \index{model}
 
 Now all we have to do is instantiate {\tt CoinTest} and call
@@ -6573,14 +6643,15 @@ time.
 How should we interpret this result?  By convention,
 5\% is the threshold of statistical significance.  If the
 p-value is less than 5\%, the effect is considered significant; otherwise
-it is not.
-\index{p-value}
-\index{statistically significant} \index{significant}
+it is not.%
+\index{p-value}%
+\index{statistically significant}%
+\index{significant}
 
 But the choice of 5\% is arbitrary, and (as we will see later) the
 p-value depends on the choice of the test statistics and
 the model of the null hypothesis.  So p-values should not be considered
-precise measurements.
+precise measurements.%
 \index{null hypothesis}
 
 I recommend interpreting p-values according to their order of
@@ -6591,27 +6662,27 @@ considered borderline.  So in this example I conclude that the
 data do not provide strong evidence that the coin is biased or not.
 
 
-\section{Testing a difference in means}
-\label{testdiff}
+\section{Testing a difference in means}%
+\label{testdiff}%
 \index{mean!difference in}
 
 One of the most common effects to test is a difference in mean
 between two groups.  In the NSFG data, we saw that the mean pregnancy
 length for first babies is slightly longer, and the mean birth weight
 is slightly smaller.  Now we will see if those effects are
-statistically significant.
-\index{National Survey of Family Growth}
-\index{NSFG}
-\index{pregnancy length}
+statistically significant.%
+\index{National Survey of Family Growth}%
+\index{NSFG}%
+\index{pregnancy length}%
 \index{length!pregnancy}
 
 For these examples, the null hypothesis is that the distributions
 for the two groups are the same.  One way to model the null
 hypothesis is by {\bf permutation}; that is, we can take values
 for first babies and others and shuffle them, treating
-the two groups as one big group:
-\index{null hypothesis}
-\index{permutation}
+the two groups as one big group:%
+\index{null hypothesis}%
+\index{permutation}%
 \index{model}
 
 \begin{verbatim}
@@ -6634,19 +6705,19 @@ class DiffMeansPermute(thinkstats2.HypothesisTest):
 \end{verbatim}
 
 {\tt data} is a pair of sequences, one for each
-group.  The test statistic is the absolute difference in the means.
+group.  The test statistic is the absolute difference in the means.%
 \index{HypothesisTest}
 
 {\tt MakeModel} records the sizes of the groups, {\tt n} and
 {\tt m}, and combines the groups into one NumPy
-array, {\tt self.pool}.
+array, {\tt self.pool}.%
 \index{NumPy}
 
 {\tt RunModel} simulates the null hypothesis by shuffling the
 pooled values and splitting them into two groups with sizes {\tt n}
 and {\tt m}.  As always, the return value from {\tt RunModel} has
-the same format as the observed data.
-\index{null hypothesis}
+the same format as the observed data.%
+\index{null hypothesis}%
 \index{model}
 
 To test the difference in pregnancy length, we run:
@@ -6664,26 +6735,27 @@ We extract pregnancy lengths as NumPy arrays, pass them as
 data to {\tt DiffMeansPermute}, and compute the p-value.  The
 result is about 0.17, which means that we expect to see a difference
 as big as the observed effect about 17\% of the time.  So
-this effect is not statistically significant.
-\index{DataFrame}
-\index{p-value}
-  \index{significant} \index{statistically significant}
+this effect is not statistically significant.%
+\index{DataFrame}%
+\index{p-value}%
+\index{significant}%
+\index{statistically significant}%
 \index{pregnancy length}
 
 \begin{figure}
 % hypothesis.py
 \centerline{\includegraphics[height=2.5in]{figs/hypothesis1.pdf}}
 \caption{CDF of difference in mean pregnancy length under the null
-hypothesis.}
+hypothesis.}%
 \label{hypothesis1}
 \end{figure}
 
 {\tt HypothesisTest} provides {\tt PlotCdf}, which plots the
 distribution of the test statistic and a gray line indicating
-the observed effect size:
-\index{thinkplot}
-\index{HypothesisTest}
-\index{Cdf}
+the observed effect size:%
+\index{thinkplot}%
+\index{HypothesisTest}%
+\index{Cdf}%
 \index{effect size}
 
 \begin{verbatim}
@@ -6694,7 +6766,7 @@ the observed effect size:
 
 Figure~\ref{hypothesis1} shows the result.  The CDF intersects the
 observed difference at 0.83, which is the complement of the p-value,
-0.17.
+0.17.%
 \index{p-value}
 
 If we run the same analysis with birth weight, the computed p-value
@@ -6703,10 +6775,11 @@ the simulation never yields an effect
 as big as the observed difference, 0.12 lbs.  So we would
 report $p < 0.001$, and
 conclude that the difference in birth weight is statistically
-significant.
-\index{birth weight}
-\index{weight!birth}
-  \index{significant} \index{statistically significant}
+significant.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{significant}%
+\index{statistically significant}
 
 
 \section{Other test statistics}
@@ -6715,8 +6788,8 @@ Choosing the best test statistic depends on what question you are
 trying to address.  For example, if the relevant question is whether
 pregnancy lengths are different for first
 babies, then it makes sense to test the absolute difference in means,
-as we did in the previous section.
-\index{test statistic}
+as we did in the previous section.%
+\index{test statistic}%
 \index{pregnancy length}
 
 If we had some reason to think that first babies are likely
@@ -6737,26 +6810,27 @@ from {\tt DiffMeansPermute}; the only difference is that
 {\tt TestStatistic} does not take the absolute value of the
 difference.  This kind of test is called {\bf one-sided} because
 it only counts one side of the distribution of differences.  The
-previous test, using both sides, is {\bf two-sided}.
-\index{one-sided test}
+previous test, using both sides, is {\bf two-sided}.%
+\index{one-sided test}%
 \index{two-sided test}
 
 For this version of the test, the p-value is 0.09.  In general
 the p-value for a one-sided test is about half the p-value for
-a two-sided test, depending on the shape of the distribution.
+a two-sided test, depending on the shape of the distribution.%
 \index{p-value}
 
 The one-sided hypothesis, that first babies are born late, is more
 specific than the two-sided hypothesis, so the p-value is smaller.
 But even for the stronger hypothesis, the difference is
-not statistically significant.
-  \index{significant} \index{statistically significant}
+not statistically significant.%
+\index{significant}%
+\index{statistically significant}
 
 We can use the same framework to test for a difference in standard
 deviation.  In Section~\ref{visualization}, we saw some evidence that
 first babies are more likely to be early or late, and less likely to
 be on time.  So we might hypothesize that the standard deviation is
-higher.  Here's how we can test that:
+higher.  Here's how we can test that:%
 \index{standard deviation}
 
 \begin{verbatim}
@@ -6770,36 +6844,37 @@ class DiffStdPermute(DiffMeansPermute):
 
 This is a one-sided test because the hypothesis is that the standard
 deviation for first babies is higher, not just different.  The p-value
-is 0.09, which is not statistically significant.
-\index{p-value}
-\index{permutation}
-  \index{significant} \index{statistically significant}
+is 0.09, which is not statistically significant.%
+\index{p-value}%
+\index{permutation}%
+\index{significant}%
+\index{statistically significant}
 
 
-\section{Testing a correlation}
+\section{Testing a correlation}%
 \label{corrtest}
 
 This framework can also test correlations.  For example, in the NSFG
 data set, the correlation between birth weight and mother's age is
 about 0.07.  It seems like older mothers have heavier babies.  But
-could this effect be due to chance?
-\index{correlation}
+could this effect be due to chance?%
+\index{correlation}%
 \index{test statistic}
 
 For the test statistic, I use
 Pearson's correlation, but Spearman's would work as well.
 If we had reason to expect positive correlation, we would do a
 one-sided test.  But since we have no such reason, I'll
-do a two-sided test using the absolute value of correlation.
-\index{Pearson coefficient of correlation}
+do a two-sided test using the absolute value of correlation.%
+\index{Pearson coefficient of correlation}%
 \index{Spearman coefficient of correlation}
 
 The null hypothesis is that there is no correlation between mother's
 age and birth weight.  By shuffling the observed values, we can
 simulate a world where the distributions of age and
-birth weight are the same, but where the variables are unrelated:
-\index{birth weight}
-\index{weight!birth}
+birth weight are the same, but where the variables are unrelated:%
+\index{birth weight}%
+\index{weight!birth}%
 \index{null hypothesis}
 
 \begin{verbatim}
@@ -6818,9 +6893,9 @@ class CorrelationPermute(thinkstats2.HypothesisTest):
 
 {\tt data} is a pair of sequences.  {\tt TestStatistic} computes the
 absolute value of Pearson's correlation.  {\tt RunModel} shuffles the
-{\tt xs} and returns simulated data.
-\index{HypothesisTest}
-\index{permutation}
+{\tt xs} and returns simulated data.%
+\index{HypothesisTest}%
+\index{permutation}%
 \index{Pearson coefficient of correlation}
 
 Here's the code that reads the data and runs the test:
@@ -6834,24 +6909,25 @@ Here's the code that reads the data and runs the test:
 \end{verbatim}
 
 I use {\tt dropna} with the {\tt subset} argument to drop rows
-that are missing either of the variables we need.
-\index{dropna}
-\index{NaN}
+that are missing either of the variables we need.%
+\index{dropna}%
+\index{NaN}%
 \index{missing values}
 
 The actual correlation is 0.07.  The computed p-value is 0; after 1000
 iterations the largest simulated correlation is 0.04.  So although the
-observed correlation is small, it is statistically significant.
-\index{p-value}
-  \index{significant} \index{statistically significant}
+observed correlation is small, it is statistically significant.%
+\index{p-value}%
+\index{significant}%
+\index{statistically significant}
 
 This example is a reminder that ``statistically significant'' does not
 always mean that an effect is important, or significant in practice.
 It only means that it is unlikely to have occurred by chance.
 
 
-\section{Testing proportions}
-\label{casino}
+\section{Testing proportions}%
+\label{casino}%
 \index{chi-squared test}
 
 Suppose you run a casino and you suspect that a customer is
@@ -6859,9 +6935,9 @@ using a crooked die; that
 is, one that has been modified to make one of the faces more
 likely than the others.  You apprehend the alleged
 cheater and confiscate the die, but now you have to prove that it
-is crooked.  You roll the die 60 times and get the following results:
-\index{casino}
-\index{dice}
+is crooked.  You roll the die 60 times and get the following results:%
+\index{casino}%
+\index{dice}%
 \index{crooked die}
 
 \begin{center}
@@ -6877,9 +6953,10 @@ Frequency &  8  &  9  &  19  &  5  &  8  &  11  \\
 On average you expect each value to appear 10 times.  In this
 dataset, the value 3 appears more often than expected, and the value 4
 appears less often.  But are these differences statistically
-significant?
-\index{frequency}
-  \index{significant} \index{statistically significant}
+significant?%
+\index{frequency}%
+\index{significant}%
+\index{statistically significant}
 
 To test this hypothesis, we can compute the expected frequency for
 each value, the difference between the expected and observed
@@ -6887,10 +6964,10 @@ frequencies, and the total absolute difference.  In this
 example, we expect each side to come up 10 times out of 60; the
 deviations from this expectation are -2, -1, 9, -5, -2, and 1; so the
 total absolute difference is 20.  How often would we see such a
-difference by chance?
+difference by chance?%
 \index{deviation}
 
-Here's a version of {\tt HypothesisTest} that answers that question:
+Here's a version of {\tt HypothesisTest} that answers that question:%
 \index{HypothesisTest}
 
 \begin{verbatim}
@@ -6914,26 +6991,27 @@ class DiceTest(thinkstats2.HypothesisTest):
 
 The data are represented as a list of frequencies: the observed
 values are {\tt [8, 9, 19, 5, 8, 11]}; the expected frequencies
-are all 10.  The test statistic is the sum of the absolute differences.
+are all 10.  The test statistic is the sum of the absolute differences.%
 \index{frequency}
 
 The null hypothesis is that the die is fair, so we simulate that by
 drawing random samples from {\tt values}.  {\tt RunModel} uses {\tt
-  Hist} to compute and return the list of frequencies.
-\index{Hist}
-\index{null hypothesis}
+  Hist} to compute and return the list of frequencies.%
+\index{Hist}%
+\index{null hypothesis}%
 \index{model}
 
 The p-value for this data is 0.13, which means that if the die is
 fair we expect to see the observed total deviation, or more, about
 13\% of the time.  So the apparent effect is not statistically
-significant.
-\index{p-value}
-\index{deviation}
-  \index{significant} \index{statistically significant}
+significant.%
+\index{p-value}%
+\index{deviation}%
+\index{significant}%
+\index{statistically significant}
 
 
-\section{Chi-squared tests}
+\section{Chi-squared tests}%
 \label{casino2}
 
 In the previous section we used total deviation as the test statistic.
@@ -6941,14 +7019,14 @@ But for testing proportions it is more common to use the chi-squared
 statistic:
 %
 \[ \goodchi^2 = \sum_i \frac{(O_i - E_i)^2}{E_i} \]
-%
+%%
 %% TODO: Consider using upper case chi, which is more strictly correct,
 %% but harder to distinguish from X.
 % 
 Where $O_i$ are the observed frequencies and $E_i$ are the expected
-frequencies.  Here's the Python code:
-\index{chi-squared test}
-\index{chi-squared statistic}
+frequencies.  Here's the Python code:%
+\index{chi-squared test}%
+\index{chi-squared statistic}%
 \index{test statistic}
 
 \begin{verbatim}
@@ -6965,7 +7043,7 @@ class DiceChiTest(DiceTest):
 Squaring the deviations (rather than taking absolute values) gives
 more weight to large deviations.  Dividing through by {\tt expected}
 standardizes the deviations, although in this case it has no effect
-because the expected frequencies are all equal.
+because the expected frequencies are all equal.%
 \index{deviation}
 
 The p-value using the chi-squared statistic is 0.04,
@@ -6974,15 +7052,16 @@ If we take the 5\% threshold seriously, we would consider this effect
 statistically significant.  But considering the two tests togther, I
 would say that the results are borderline.  I would not rule out the
 possibility that the die is crooked, but I would not convict the
-accused cheater.
-\index{p-value}
-  \index{significant} \index{statistically significant}
+accused cheater.%
+\index{p-value}%
+\index{significant}%
+\index{statistically significant}
 
 This example demonstrates an important point: the p-value depends
 on the choice of test statistic and the model of the null hypothesis,
 and sometimes these choices determine whether an effect is
-statistically significant or not.
-\index{null hypothesis}
+statistically significant or not.%
+\index{null hypothesis}%
 \index{model}
 
 
@@ -6994,12 +7073,13 @@ mean and standard deviation are not statistically significant.  But in
 Section~\ref{visualization}, we saw several apparent differences
 in the distribution of pregnancy length, especially in the range from
 35 to 43 weeks.  To see whether those differences are statistically
-significant, we can use a test based on a chi-squared statistic.
-\index{standard deviation}
-\index{statistically significant} \index{significant}
+significant, we can use a test based on a chi-squared statistic.%
+\index{standard deviation}%
+\index{statistically significant}%
+\index{significant}%
 \index{pregnancy length}
 
-The code combines elements from previous examples:
+The code combines elements from previous examples:%
 \index{HypothesisTest}
 
 \begin{verbatim}
@@ -7025,10 +7105,10 @@ hypothesis is that both samples are drawn from the same distribution.
 {\tt MakeModel} models that distribution by pooling the two
 samples using {\tt hstack}.  Then {\tt RunModel} generates
 simulated data by shuffling the pooled sample and splitting it
-into two parts.
-\index{null hypothesis}
-\index{model}
-\index{hstack}
+into two parts.%
+\index{null hypothesis}%
+\index{model}%
+\index{hstack}%
 \index{pregnancy length}
 
 {\tt MakeModel} also defines {\tt values}, which is the
@@ -7054,7 +7134,7 @@ Here's the code that computes the test statistic:
 \end{verbatim}
 
 {\tt TestStatistic} computes the chi-squared statistic for
-first babies and others, and adds them.
+first babies and others, and adds them.%
 \index{chi-squared statistic}
 
 {\tt ChiSquared} takes a sequence of pregnancy lengths, computes
@@ -7068,34 +7148,36 @@ For the NSFG data the total chi-squared statistic is 102, which
 doesn't mean much by itself.  But after 1000 iterations, the largest
 test statistic generated under the null hypothesis is 32.  We conclude
 that the observed chi-squared statistic is unlikely under the null
-hypothesis, so the apparent effect is statistically significant.
-\index{null hypothesis}
-\index{statistically significant} \index{significant}
+hypothesis, so the apparent effect is statistically significant.%
+\index{null hypothesis}%
+\index{statistically significant}%
+\index{significant}
 
 This example demonstrates a limitation of chi-squared tests: they
 indicate that there is a difference between the two groups,
 but they don't say anything specific about what the difference is.
 
 
-\section{Errors}
+\section{Errors}%
 \index{error}
 
 In classical hypothesis testing, an effect is considered statistically
 significant if the p-value is below some threshold, commonly 5\%.
-This procedure raises two questions:
-\index{p-value}
-\index{threshold}
-\index{statistically significant} \index{significant}
+This procedure raises two questions:%
+\index{p-value}%
+\index{threshold}%
+\index{statistically significant}%
+\index{significant}
 
 \begin{itemize}
 
 \item If the effect is actually due to chance, what is the probability
 that we will wrongly consider it significant?  This
-probability is the {\bf false positive rate}.
+probability is the {\bf false positive rate}.%
 \index{false positive}
 
 \item If the effect is real, what is the chance that the hypothesis
-test will fail?  This probability is the {\bf false negative rate}.
+test will fail?  This probability is the {\bf false negative rate}.%
 \index{false negative}
 
 \end{itemize}
@@ -7107,8 +7189,8 @@ threshold is 5\%, the false positive rate is 5\%.  Here's why:
 
 \item If there is no real effect, the null hypothesis is true, so we
   can compute the distribution of the test statistic by simulating the
-  null hypothesis.  Call this distribution $\CDF_T$.
-\index{null hypothesis}
+  null hypothesis.  Call this distribution $\CDF_T$.%
+\index{null hypothesis}%
 \index{CDF}
 
 \item Each time we run an experiment, we get a test statistic, $t$,
@@ -7127,18 +7209,18 @@ So if you perform one hypothesis test with a 5\% threshold, you expect
 a false positive 1 time in 20.
 
 
-\section{Power}
+\section{Power}%
 \label{power}
 
 The false negative rate is harder to compute because it depends on
 the actual effect size, and normally we don't know that.
 One option is to compute a rate
-conditioned on a hypothetical effect size.
+conditioned on a hypothetical effect size.%
 \index{effect size}
 
 For example, if we assume that the observed difference between groups
 is accurate, we can use the observed samples as a model of the
-population and run hypothesis tests with simulated data:
+population and run hypothesis tests with simulated data:%
 \index{model}
 
 \begin{verbatim}
@@ -7161,12 +7243,12 @@ def FalseNegRate(data, num_runs=100):
 {\tt FalseNegRate} takes data in the form of two sequences, one for
 each group.  Each time through the loop, it simulates an experiment by
 drawing a random sample from each group and running a hypothesis test.
-Then it checks the result and counts the number of false negatives.
-\index{Resample}
+Then it checks the result and counts the number of false negatives.%
+\index{Resample}%
 \index{permutation}
 
 {\tt Resample} takes a sequence and draws a sample with the same
-length, with replacement:
+length, with replacement:%
 \index{replacement}
 
 \begin{verbatim}
@@ -7184,22 +7266,22 @@ Here's the code that tests pregnancy lengths:
 
 The result is about 70\%, which means that if the actual difference in
 mean pregnancy length is 0.078 weeks, we expect an experiment with this
-sample size to yield a negative test 70\% of the time.
+sample size to yield a negative test 70\% of the time.%
 \index{pregnancy length}
 
 This result is often presented the other way around: if the actual
 difference is 0.078 weeks, we should expect a positive test only 30\%
 of the time.  This ``correct positive rate'' is called the {\bf power}
 of the test, or sometimes ``sensitivity''.  It reflects the ability of
-the test to detect an effect of a given size.
-\index{power}
-\index{sensitivity}
+the test to detect an effect of a given size.%
+\index{power}%
+\index{sensitivity}%
 \index{correct positive}
 
 In this example, the test had only a 30\% chance of yielding a
 positive result (again, assuming that the difference is 0.078 weeks).
 As a rule of thumb, a power of 80\% is considered acceptable, so
-we would say that this test was ``underpowered.''
+we would say that this test was ``underpowered.''%
 \index{underpowered}
 
 In general a negative hypothesis test does not imply that there is no
@@ -7207,7 +7289,7 @@ difference between the groups; instead it suggests that if there is a
 difference, it is too small to detect with this sample size.
 
 
-\section{Replication}
+\section{Replication}%
 \label{replication}
 
 The hypothesis testing process I demonstrated in this chapter is not,
@@ -7216,28 +7298,29 @@ strictly speaking, good practice.
 First, I performed multiple tests.  If you run one hypothesis test,
 the chance of a false positive is about 1 in 20, which might be
 acceptable.  But if you run 20 tests, you should expect at least one
-false positive, most of the time.
+false positive, most of the time.%
 \index{multiple tests}
 
 Second, I used the same dataset for exploration and testing.  If
 you explore a large dataset, find a surprising effect, and then test
 whether it is significant, you have a good chance of generating a
-false positive.
-\index{statistically significant} \index{significant}
+false positive.%
+\index{statistically significant}%
+\index{significant}
 
 To compensate for multiple tests, you can adjust the p-value
 threshold (see
   \url{https://en.wikipedia.org/wiki/Holm-Bonferroni_method}).  Or you
 can address both problems by partitioning the data, using one set for
-exploration and the other for testing.
-\index{p-value}
+exploration and the other for testing.%
+\index{p-value}%
 \index{Holm-Bonferroni method}
 
 In some fields these practices are required or at least encouraged.
 But it is also common to address these problems implicitly by
 replicating published results.  Typically the first paper to report a
 new result is considered exploratory.  Subsequent papers that
-replicate the result with new data are considered confirmatory.
+replicate the result with new data are considered confirmatory.%
 \index{confirmatory result}
 
 As it happens, we have an opportunity to replicate the results in this
@@ -7245,20 +7328,21 @@ chapter.  The first edition of this book is based on Cycle 6 of the
 NSFG, which was released in 2002.  In October 2011, the CDC released
 additional data based on interviews conducted from 2006--2010.  {\tt
   nsfg2.py} contains code to read and clean this data.  In the new
-dataset:
+dataset:%
 \index{NSFG}
 
 \begin{itemize}
 
 \item The difference in mean pregnancy length is
 0.16 weeks and statistically significant with $p < 0.001$ (compared
-to 0.078 weeks in the original dataset).
-\index{statistically significant} \index{significant}
+to 0.078 weeks in the original dataset).%
+\index{statistically significant}%
+\index{significant}%
 \index{pregnancy length}
 
 \item The difference in birth weight is 0.17 pounds with $p < 0.001$
-(compared to 0.12 lbs in the original dataset).
-\index{birth weight}
+(compared to 0.12 lbs in the original dataset).%
+\index{birth weight}%
 \index{weight!birth}
 
 \item The correlation between birth weight and mother's age is
@@ -7283,18 +7367,18 @@ A solution to these exercises is in \verb"chap09soln.py".
 As sample size increases, the power of a hypothesis test increases,
 which means it is more likely to be positive if the effect is real.
 Conversely, as sample size decreases, the test is less likely to
-be positive even if the effect is real.
+be positive even if the effect is real.%
 \index{sample size}
 
 To investigate this behavior, run the tests in this chapter with
 different subsets of the NSFG data.  You can use {\tt thinkstats2.SampleRows}
-to select a random subset of the rows in a DataFrame.
-\index{National Survey of Family Growth}
-\index{NSFG}
+to select a random subset of the rows in a DataFrame.%
+\index{National Survey of Family Growth}%
+\index{NSFG}%
 \index{DataFrame}
 
 What happens to the p-values of these tests as sample size decreases?
-What is the smallest sample size that yields a positive test?
+What is the smallest sample size that yields a positive test?%
 \index{p-value}
 \end{exercise}
 
@@ -7305,28 +7389,28 @@ What is the smallest sample size that yields a positive test?
 In Section~\ref{testdiff}, we simulated the null hypothesis by
 permutation; that is, we treated the observed values as if they
 represented the entire population, and randomly assigned the
-members of the population to the two groups.
-\index{null hypothesis}
+members of the population to the two groups.%
+\index{null hypothesis}%
 \index{permutation}
 
 An alternative is to use the sample to estimate the distribution for
 the population, then draw a random sample from that distribution.
 This process is called {\bf resampling}.  There are several ways to
 implement resampling, but one of the simplest is to draw a sample
-with replacement from the observed values, as in Section~\ref{power}.
-\index{resampling}
+with replacement from the observed values, as in Section~\ref{power}.%
+\index{resampling}%
 \index{replacement}
 
 Write a class named {\tt DiffMeansResample} that inherits from
 {\tt DiffMeansPermute} and overrides {\tt RunModel} to implement
-resampling, rather than permutation.
+resampling, rather than permutation.%
 \index{permutation}
 
 Use this model to test the differences in pregnancy length and
-birth weight.  How much does the model affect the results?
-\index{model}
-\index{birth weight}
-\index{weight!birth}
+birth weight.  How much does the model affect the results?%
+\index{model}%
+\index{birth weight}%
+\index{weight!birth}%
 \index{pregnancy length}
 
 \end{exercise}
@@ -7337,62 +7421,63 @@ birth weight.  How much does the model affect the results?
 \begin{itemize}
 
 \item hypothesis testing: The process of determining whether an apparent
-effect is statistically significant.
+effect is statistically significant.%
 \index{hypothesis testing}
 
-\item test statistic: A statistic used to quantify an effect size.
-\index{test statistic}
+\item test statistic: A statistic used to quantify an effect size.%
+\index{test statistic}%
 \index{effect size}
 
 \item null hypothesis: A model of a system based on the assumption that
-an apparent effect is due to chance.
+an apparent effect is due to chance.%
 \index{null hypothesis}
 
-\item p-value: The probability that an effect could occur by chance.
+\item p-value: The probability that an effect could occur by chance.%
 \index{p-value}
 
 \item statistically significant: An effect is statistically
-  significant if it is unlikely to occur by chance.
-  \index{significant} \index{statistically significant}
+  significant if it is unlikely to occur by chance.%
+\index{significant}%
+\index{statistically significant}
 
 \item permutation test: A way to compute p-values by generating
-  permutations of an observed dataset.
-  \index{permutation test}
+  permutations of an observed dataset.%
+\index{permutation test}
 
 \item resampling test: A way to compute p-values by generating
-  samples, with replacement, from an observed dataset.
-  \index{resampling test}
+  samples, with replacement, from an observed dataset.%
+\index{resampling test}
 
 \item two-sided test: A test that asks, ``What is the chance of an effect
 as big as the observed effect, positive or negative?''
 
 \item one-sided test: A test that asks, ``What is the chance of an effect
-as big as the observed effect, and with the same sign?''
-\index{one-sided test}
-\index{two-sided test}
-\index{test!one-sided}
+as big as the observed effect, and with the same sign?''%
+\index{one-sided test}%
+\index{two-sided test}%
+\index{test!one-sided}%
 \index{test!two-sided}
 
 \item chi-squared test: A test that uses the chi-squared statistic as
-the test statistic.
+the test statistic.%
 \index{chi-squared test}
 
-\item false positive: The conclusion that an effect is real when it is not.
+\item false positive: The conclusion that an effect is real when it is not.%
 \index{false positive}
 
 \item false negative: The conclusion that an effect is due to chance when it
-is not.
+is not.%
 \index{false negative}
 
 \item power: The probability of a positive test if the null hypothesis
-is false.
-\index{power}
+is false.%
+\index{power}%
 \index{null hypothesis}
 
 \end{itemize}
 
 
-\chapter{Linear least squares}
+\chapter{Linear least squares}%
 \label{linear}
 
 The code for this chapter is in {\tt linear.py}.  For information
@@ -7406,20 +7491,21 @@ relationship, but not the slope.  There are several ways to estimate
 the slope; the most common is a {\bf linear least squares fit}.  A
 ``linear fit'' is a line intended to model the relationship between
 variables.  A ``least squares'' fit is one that minimizes the mean
-squared error (MSE) between the line and the data.
-\index{least squares fit}
-\index{linear least squares}
+squared error (MSE) between the line and the data.%
+\index{least squares fit}%
+\index{linear least squares}%
 \index{model}
 
 Suppose we have a sequence of points, {\tt ys}, that we want to
 express as a function of another sequence {\tt xs}.  If there is a
 linear relationship between {\tt xs} and {\tt ys} with intercept {\tt
   inter} and slope {\tt slope}, we expect each {\tt y[i]} to be
-{\tt inter + slope * x[i]}.  \index{residuals}
+{\tt inter + slope * x[i]}.%
+\index{residuals}
 
 But unless the correlation is perfect, this prediction is only
 approximate.  The vertical deviation from the line, or {\bf residual},
-is
+is%
 \index{deviation}
 
 \begin{verbatim}
@@ -7429,14 +7515,14 @@ res = ys - (inter + slope * xs)
 The residuals might be due to random factors like measurement error,
 or non-random factors that are unknown.  For example, if we are
 trying to predict weight as a function of height, unknown factors
-might include diet, exercise, and body type.
-\index{slope}
-\index{intercept}
+might include diet, exercise, and body type.%
+\index{slope}%
+\index{intercept}%
 \index{measurement error}
 
 If we get the parameters {\tt inter} and {\tt slope} wrong, the residuals
 get bigger, so it makes intuitive sense that the parameters we want
-are the ones that minimize the residuals.
+are the ones that minimize the residuals.%
 \index{parameter}
 
 We might try to minimize the absolute value of the
@@ -7458,8 +7544,9 @@ so much weight that the largest residual always dominates.
   mean 0 and constant (but unknown) variance, then the least squares
   fit is also the maximum likelihood estimator of {\tt inter} and {\tt
     slope}.  See
-  \url{https://en.wikipedia.org/wiki/Linear_regression}.  \index{MLE}
-  \index{maximum likelihood estimator}
+  \url{https://en.wikipedia.org/wiki/Linear_regression}.%
+\index{MLE}%
+\index{maximum likelihood estimator}%
 \index{correlation}
 
 \item The values of {\tt inter} and {\tt slope} that minimize
@@ -7470,8 +7557,8 @@ so much weight that the largest residual always dominates.
 The last reason made sense when computational efficiency was more
 important than choosing the method most appropriate to the problem
 at hand.  That's no longer the case, so it is worth considering
-whether squared residuals are the right thing to minimize.
-\index{computational methods}
+whether squared residuals are the right thing to minimize.%
+\index{computational methods}%
 \index{squared residuals}
 
 For example, if you are using {\tt xs} to predict values of {\tt ys},
@@ -7479,14 +7566,14 @@ guessing too high might be better (or worse) than guessing too low.
 In that case you might want to compute some cost function for each
 residual, and minimize total cost, {\tt sum(cost(res))}.
 However, computing a least squares fit is quick, easy and often good
-enough.  
+enough.%
 \index{cost function}
 
 
 \section{Implementation}
 
 {\tt thinkstats2} provides simple functions that demonstrate
-linear least squares:
+linear least squares:%
 \index{LeastSquares}
 
 \begin{verbatim}
@@ -7504,12 +7591,12 @@ def LeastSquares(xs, ys):
 {\tt xs} and {\tt ys} and returns the estimated parameters {\tt inter}
 and {\tt slope}.
 For details on how it works, see
-\url{http://wikipedia.org/wiki/Numerical_methods_for_linear_least_squares}.
+\url{http://wikipedia.org/wiki/Numerical_methods_for_linear_least_squares}.%
 \index{parameter}
 
 {\tt thinkstats2} also provides {\tt FitLine}, which takes {\tt inter}
 and {\tt slope} and returns the fitted line for a sequence
-of {\tt xs}.
+of {\tt xs}.%
 \index{FitLine}
 
 \begin{verbatim}
@@ -7520,9 +7607,9 @@ def FitLine(xs, inter, slope):
 \end{verbatim}
 
 We can use these functions to compute the least squares fit for
-birth weight as a function of mother's age.
-\index{birth weight}
-\index{weight!birth}
+birth weight as a function of mother's age.%
+\index{birth weight}%
+\index{weight!birth}%
 \index{age}
 
 \begin{verbatim}
@@ -7539,10 +7626,10 @@ The estimated intercept and slope are 6.8 lbs and 0.017 lbs per year.
 These values are hard to interpret in this form: the intercept is
 the expected weight of a baby whose mother is 0 years old, which
 doesn't make sense in context, and the slope is too small to
-grasp easily.
-\index{slope}
-\index{intercept}
-\index{dropna}
+grasp easily.%
+\index{slope}%
+\index{intercept}%
+\index{dropna}%
 \index{NaN}
 
 Instead of presenting the intercept at $x=0$, it
@@ -7555,26 +7642,26 @@ per year, or 0.17 pounds per decade.
 % linear.py
 \centerline{\includegraphics[height=2.5in]{figs/linear1.pdf}}
 \caption{Scatter plot of birth weight and mother's age with
-a linear fit.}
+a linear fit.}%
 \label{linear1}
 \end{figure}
 
 Figure~\ref{linear1} shows a scatter plot of birth weight and age
 along with the fitted line.  It's a good idea to look at a figure like
 this to assess whether the relationship is linear and whether the
-fitted line seems like a good model of the relationship.
-\index{birth weight}
-\index{weight!birth}
-\index{scatter plot}
-\index{plot!scatter}
+fitted line seems like a good model of the relationship.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{scatter plot}%
+\index{plot!scatter}%
 \index{model}
 
 
-\section{Residuals}
+\section{Residuals}%
 \label{residuals}
 
 Another useful test is to plot the residuals.
-{\tt thinkstats2} provides a function that computes residuals:
+{\tt thinkstats2} provides a function that computes residuals:%
 \index{residuals}
 
 \begin{verbatim}
@@ -7592,7 +7679,7 @@ the differences between the actual values and the fitted line.
 \begin{figure}
 % linear.py
 \centerline{\includegraphics[height=2.5in]{figs/linear2.pdf}}
-\caption{Residuals of the linear fit.}
+\caption{Residuals of the linear fit.}%
 \label{linear2}
 \end{figure}
 
@@ -7602,7 +7689,7 @@ Figure~\ref{linear2} shows the 25th, 50th and 75th percentiles of
 the residuals for each age group.  The median is near zero, as
 expected, and the interquartile range is about 2 pounds.  So if we
 know the mother's age, we can guess the baby's weight within a pound,
-about 50\% of the time.
+about 50\% of the time.%
 \index{visualization}
 
 Ideally these lines should be flat, indicating that the residuals are
@@ -7610,12 +7697,12 @@ random, and parallel, indicating that the variance of the residuals is
 the same for all age groups.  In fact, the lines are close to
 parallel, so that's good; but they have some curvature, indicating
 that the relationship is nonlinear.  Nevertheless, the linear fit
-is a simple model that is probably good enough for some purposes.
-\index{model}
+is a simple model that is probably good enough for some purposes.%
+\index{model}%
 \index{nonlinear}
 
 
-\section{Estimation}
+\section{Estimation}%
 \label{regest}
 
 The parameters {\tt slope} and {\tt inter} are estimates based on a
@@ -7624,24 +7711,24 @@ measurement error, and sampling error.  As discussed in
 Chapter~\ref{estimation}, sampling bias is caused by non-representative
 sampling, measurement error is caused by errors in collecting
 and recording data, and sampling error is the result of measuring a
-sample rather than the entire population.
-\index{sampling bias}
-\index{bias!sampling}
-\index{measurement error}
-\index{sampling error}
+sample rather than the entire population.%
+\index{sampling bias}%
+\index{bias!sampling}%
+\index{measurement error}%
+\index{sampling error}%
 \index{estimation}
 
 To assess sampling error, we ask, ``If we run this experiment again,
 how much variability do we expect in the estimates?''  We can
 answer this question by running simulated experiments and computing
-sampling distributions of the estimates.
-\index{sampling error}
+sampling distributions of the estimates.%
+\index{sampling error}%
 \index{sampling distribution}
 
 I simulate the experiments by resampling the data; that is, I treat
 the observed pregnancies as if they were the entire population
-and draw samples, with replacement, from the observed sample.
-\index{simulation}
+and draw samples, with replacement, from the observed sample.%
+\index{simulation}%
 \index{replacement}
 
 \begin{verbatim}
@@ -7663,8 +7750,8 @@ birth, and {\tt iters}, the number of experiments to simulate.  It
 uses {\tt ResampleRows} to resample the observed pregnancies.  We've
 already seen {\tt SampleRows}, which chooses random rows from a
 DataFrame.  {\tt thinkstats2} also provides {\tt ResampleRows}, which
-returns a sample the same size as the original:
-\index{DataFrame}
+returns a sample the same size as the original:%
+\index{DataFrame}%
 \index{resampling}
 
 \begin{verbatim}
@@ -7674,11 +7761,11 @@ def ResampleRows(df):
 
 After resampling, we use the simulated sample to estimate parameters.
 The result is two sequences: the estimated intercepts and estimated
-slopes.
+slopes.%
 \index{parameter}
 
 I summarize the sampling distributions by printing the standard
-error and confidence interval:
+error and confidence interval:%
 \index{sampling distribution}
 
 \begin{verbatim}
@@ -7691,9 +7778,9 @@ def Summarize(estimates, actual=None):
 \end{verbatim}
 
 {\tt Summarize} takes a sequence of estimates and the actual value.
-It prints the mean of the estimates, the standard error and 
-a 90\% confidence interval.
-\index{standard error}
+It prints the mean of the estimates, the standard error and
+a 90\% confidence interval.%
+\index{standard error}%
 \index{confidence interval}
 
 For the intercept, the mean estimate is 6.83, with standard error
@@ -7735,15 +7822,15 @@ of {\tt inter} and {\tt slope} and stores the results in a sequence,
 upper and lower percentiles of {\tt y} for each value of {\tt x}.
 For a 90\% confidence interval, it selects the 5th and 95th percentiles.
 {\tt FillBetween} draws a polygon that fills the space between two
-lines.
-\index{thinkplot}
+lines.%
+\index{thinkplot}%
 \index{FillBetween}
 
 \begin{figure}
 % linear.py
 \centerline{\includegraphics[height=2.5in]{figs/linear3.pdf}}
 \caption{50\% and 90\% confidence intervals showing variability in the
-  fitted line due to sampling error of {\tt inter} and {\tt slope}.}
+  fitted line due to sampling error of {\tt inter} and {\tt slope}.}%
 \label{linear3}
 \end{figure}
 
@@ -7755,33 +7842,33 @@ sampling error; the effect is smaller for values near the mean and
 larger for the extremes.
 
 
-\section{Goodness of fit}
-\label{goodness}
+\section{Goodness of fit}%
+\label{goodness}%
 \index{goodness of fit}
 
 There are several ways to measure the quality of a linear model, or
 {\bf goodness of fit}.  One of the simplest is the standard deviation
-of the residuals.
-\index{standard deviation}
+of the residuals.%
+\index{standard deviation}%
 \index{model}
 
 If you use a linear model to make predictions, {\tt Std(res)}
 is the root mean squared error (RMSE) of your predictions.  For
 example, if you use mother's age to guess birth weight, the RMSE of
-your guess would be 1.40 lbs.
-\index{birth weight}
+your guess would be 1.40 lbs.%
+\index{birth weight}%
 \index{weight!birth}
 
 If you guess birth weight without knowing the mother's age, the RMSE
 of your guess is {\tt Std(ys)}, which is 1.41 lbs.  So in this
 example, knowing a mother's age does not improve the predictions
-substantially.
+substantially.%
 \index{prediction}
 
 Another way to measure goodness of fit is  the {\bf
-  coefficient of determination}, usually denoted $R^2$ and 
-called ``R-squared'':
-\index{coefficient of determination}
+  coefficient of determination}, usually denoted $R^2$ and
+called ``R-squared'':%
+\index{coefficient of determination}%
 \index{r-squared}
 
 \begin{verbatim}
@@ -7792,7 +7879,7 @@ def CoefDetermination(ys, res):
 {\tt Var(res)} is the MSE of your guesses using the model,
 {\tt Var(ys)} is the MSE without it.   So their ratio is the fraction
 of MSE that remains if you use the model, and $R^2$ is the fraction
-of MSE the model eliminates.
+of MSE the model eliminates.%
 \index{MSE}
 
 For birth weight and mother's age, $R^2$ is 0.0047, which means
@@ -7801,22 +7888,22 @@ birth weight.
 
 There is a simple relationship between the coefficient of
 determination and Pearson's coefficient of correlation: $R^2 = \rho^2$.
-For example, if $\rho$ is 0.8 or -0.8, $R^2 = 0.64$.
+For example, if $\rho$ is 0.8 or -0.8, $R^2 = 0.64$.%
 \index{Pearson coefficient of correlation}
 
 Although $\rho$ and $R^2$ are often used to quantify the strength of a
 relationship, they are not easy to interpret in terms of predictive
 power.  In my opinion, {\tt Std(res)} is the best representation
 of the quality of prediction, especially if it is presented
-in relation to {\tt Std(ys)}.
-\index{coefficient of determination}
+in relation to {\tt Std(ys)}.%
+\index{coefficient of determination}%
 \index{r-squared}
 
 For example, when people talk about the validity of the SAT
 (a standardized test used for college admission in the U.S.) they
 often talk about correlations between SAT scores and other measures of
-intelligence.
-\index{SAT}
+intelligence.%
+\index{SAT}%
 \index{IQ}
 
 According to one study, there is a Pearson correlation of
@@ -7841,9 +7928,9 @@ points.  A correlation of 0.72 yields a reduction in RMSE of only
 
 If you see a correlation that looks impressive, remember that $R^2$ is
 a better indicator of reduction in MSE, and reduction in RMSE is a
-better indicator of predictive power.
-\index{coefficient of determination}
-\index{r-squared}
+better indicator of predictive power.%
+\index{coefficient of determination}%
+\index{r-squared}%
 \index{prediction}
 
 
@@ -7852,10 +7939,10 @@ better indicator of predictive power.
 The effect of mother's age on birth weight is small, and has little
 predictive power.  So is it possible that the apparent relationship
 is due to chance?  There are several ways we might test the
-results of a linear fit.
-\index{birth weight}
-\index{weight!birth}
-\index{model}
+results of a linear fit.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{model}%
 \index{linear model}
 
 One option is to test whether the apparent reduction in MSE is due to
@@ -7867,18 +7954,19 @@ mother's age and birth weight.  In fact, because $R^2 = \rho^2$, a
 one-sided test of $R^2$ is equivalent to a two-sided test of $\rho$.
 We've already done that test, and found $p < 0.001$, so we conclude
 that the apparent relationship between mother's age and birth weight
-is statistically significant.
-\index{null hypothesis}
-\index{permutation}
-\index{coefficient of determination}
-\index{r-squared}
-  \index{significant} \index{statistically significant}
+is statistically significant.%
+\index{null hypothesis}%
+\index{permutation}%
+\index{coefficient of determination}%
+\index{r-squared}%
+\index{significant}%
+\index{statistically significant}
 
 Another approach is to test whether the apparent slope is due to chance.
 The null hypothesis is that the slope is actually zero; in that case
 we can model the birth weights as random variations around their mean.
-Here's a HypothesisTest for this model:
-\index{HypothesisTest}
+Here's a HypothesisTest for this model:%
+\index{HypothesisTest}%
 \index{model}
 
 \begin{verbatim}
@@ -7905,9 +7993,9 @@ test statistic is the slope estimated by {\tt LeastSquares}.
 The model of the null hypothesis is represented by the mean weight
 of all babies and the deviations from the mean.  To
 generate simulated data, we permute the deviations and add them to
-the mean.
-\index{deviation}
-\index{null hypothesis}
+the mean.%
+\index{deviation}%
+\index{null hypothesis}%
 \index{permutation}
 
 Here's the code that runs the hypothesis test:
@@ -7920,16 +8008,16 @@ Here's the code that runs the hypothesis test:
 \end{verbatim}
 
 The p-value is less than $0.001$, so although the estimated
-slope is small, it is unlikely to be due to chance.
-\index{p-value}
-\index{dropna}
+slope is small, it is unlikely to be due to chance.%
+\index{p-value}%
+\index{dropna}%
 \index{NaN}
 
 Estimating the p-value by simulating the null hypothesis is strictly
 correct, but there is a simpler alternative.  Remember that we already
 computed the sampling distribution of the slope, in
 Section~\ref{regest}.  To do that, we assumed that the observed slope
-was correct and simulated experiments by resampling.
+was correct and simulated experiments by resampling.%
 \index{null hypothesis}
 
 Figure~\ref{linear4} shows the sampling distribution of the
@@ -7938,8 +8026,8 @@ generated under the null hypothesis.  The sampling distribution
 is centered about the estimated slope, 0.017 lbs/year, and the slopes
 under the null hypothesis are centered around 0; but other than
 that, the distributions are identical.  The distributions are
-also symmetric, for reasons we will see in Section~\ref{CLT}.
-\index{symmetric}
+also symmetric, for reasons we will see in Section~\ref{CLT}.%
+\index{symmetric}%
 \index{sampling distribution}
 
 \begin{figure}
@@ -7948,17 +8036,17 @@ also symmetric, for reasons we will see in Section~\ref{CLT}.
 \caption{The sampling distribution of the estimated
 slope and the distribution of slopes
 generated under the null hypothesis.  The vertical lines are at 0
-and the observed slope, 0.017 lbs/year.}
+and the observed slope, 0.017 lbs/year.}%
 \label{linear4}
 \end{figure}
 
-So we could estimate the p-value two ways:
+So we could estimate the p-value two ways:%
 \index{p-value}
 
 \begin{itemize}
 
 \item Compute the probability that the slope under the null
-hypothesis exceeds the observed slope.
+hypothesis exceeds the observed slope.%
 \index{null hypothesis}
 
 \item Compute the probability that the slope in the sampling
@@ -7972,12 +8060,12 @@ The second option is easier because we normally want to compute the
 sampling distribution of the parameters anyway.  And it is a good
 approximation unless the sample size is small {\em and\/} the
 distribution of residuals is skewed.  Even then, it is usually good
-enough, because p-values don't have to be precise.
-\index{skewness}
+enough, because p-values don't have to be precise.%
+\index{skewness}%
 \index{parameter}
 
 Here's the code that estimates the p-value of the slope using the
-sampling distribution:
+sampling distribution:%
 \index{sampling distribution}
 
 \begin{verbatim}
@@ -7989,15 +8077,16 @@ sampling distribution:
 Again, we find $p < 0.001$.  
 
 
-\section{Weighted resampling}
+\section{Weighted resampling}%
 \label{weighted}
 
 So far we have treated the NSFG data as if it were a representative
 sample, but as I mentioned in Section~\ref{nsfg}, it is not.  The
 survey deliberately oversamples several groups in order to
 improve the chance of getting statistically significant results; that
-is, in order to improve the power of tests involving these groups.
-  \index{significant} \index{statistically significant}
+is, in order to improve the power of tests involving these groups.%
+\index{significant}%
+\index{statistically significant}
 
 This survey design is useful for many purposes, but it means that we
 cannot use the sample to estimate values for the general
@@ -8006,10 +8095,10 @@ population without accounting for the sampling process.
 For each respondent, the NSFG data includes a variable called {\tt
   finalwgt}, which is the number of people in the general population
 the respondent represents.  This value is called a {\bf sampling
-  weight}, or just ``weight.''
-\index{sampling weight}
-\index{weight}
-\index{weighted resampling}
+  weight}, or just ``weight.''%
+\index{sampling weight}%
+\index{weight}%
+\index{weighted resampling}%
 \index{resampling!weighted}
 
 As an example, if you survey 100,000 people in a country of 300
@@ -8022,12 +8111,12 @@ can draw samples from the survey using probabilities proportional
 to sampling weights.  Then, for any quantity we want to estimate, we can
 generate sampling distributions, standard errors, and confidence
 intervals.  As an example, I will estimate mean birth weight with
-and without sampling weights.
-\index{standard error}
-\index{confidence interval}
-\index{birth weight}
-\index{weight!birth}
-\index{sampling distribution}
+and without sampling weights.%
+\index{standard error}%
+\index{confidence interval}%
+\index{birth weight}%
+\index{weight!birth}%
+\index{sampling distribution}%
 \index{oversampling}
 
 In Section~\ref{regest}, we saw {\tt ResampleRows}, which chooses
@@ -8036,8 +8125,8 @@ Now we need to do the same thing using probabilities
 proportional to sampling weights.
 {\tt ResampleRowsWeighted} takes a DataFrame, resamples rows according
 to the weights in {\tt finalwgt}, and returns a DataFrame containing
-the resampled rows:
-\index{DataFrame}
+the resampled rows:%
+\index{DataFrame}%
 \index{resampling}
 
 \begin{verbatim}
@@ -8056,12 +8145,13 @@ weights.
 
 {\tt indices} is a sequence of row indices; {\tt sample} is a
 DataFrame that contains the selected rows.  Since we sample with
-replacement, the same row might appear more than once.  \index{Cdf}
+replacement, the same row might appear more than once.%
+\index{Cdf}%
 \index{replacement}
 
 Now we can compare the effect of resampling with and without
 weights.  Without weights, we generate the sampling distribution
-like this:
+like this:%
 \index{sampling distribution}
 
 \begin{verbatim}
@@ -8101,8 +8191,8 @@ In this example, the effect of weighting is small but non-negligible.
 The difference in estimated means, with and without weighting, is
 about 0.08 pounds, or 1.3 ounces.  This difference is substantially
 larger than the standard error of the estimate, 0.014 pounds, which
-implies that the difference is not due to chance.
-\index{standard error}
+implies that the difference is not due to chance.%
+\index{standard error}%
 \index{confidence interval}
 
 
@@ -8117,9 +8207,9 @@ fit for log(weight) versus height.
 How would you best present the estimated parameters for a model
 like this where one of the variables is log-transformed?
 If you were trying to guess
-someone's weight, how much would it help to know their height?
-\index{Behavioral Risk Factor Surveillance System}
-\index{BRFSS}
+someone's weight, how much would it help to know their height?%
+\index{Behavioral Risk Factor Surveillance System}%
+\index{BRFSS}%
 \index{model}
 
 Like the NSFG, the BRFSS oversamples some groups and provides
@@ -8128,10 +8218,10 @@ name for these weights is {\tt finalwt}.
 Use resampling, with and without weights, to estimate the mean height
 of respondents in the BRFSS, the standard error of the mean, and a
 90\% confidence interval.  How much does correct weighting affect the
-estimates?
-\index{confidence interval}
-\index{standard error}
-\index{oversampling}
+estimates?%
+\index{confidence interval}%
+\index{standard error}%
+\index{oversampling}%
 \index{sampling weight}
 \end{exercise}
 
@@ -8141,46 +8231,47 @@ estimates?
 \begin{itemize}
 
 \item linear fit: a line intended to model the relationship between
-variables.  \index{linear fit}
+variables.%
+\index{linear fit}
 
 \item least squares fit: A model of a dataset that minimizes the
-sum of squares of the residuals.
+sum of squares of the residuals.%
 \index{least squares fit}
 
-\item residual: The deviation of an actual value from a model.
+\item residual: The deviation of an actual value from a model.%
 \index{residuals}
 
-\item goodness of fit: A measure of how well a model fits data.
+\item goodness of fit: A measure of how well a model fits data.%
 \index{goodness of fit}
 
 \item coefficient of determination: A statistic intended to
-quantify goodness of fit.
+quantify goodness of fit.%
 \index{coefficient of determination}
 
 \item sampling weight: A value associated with an observation in a
-  sample that indicates what part of the population it represents.
+  sample that indicates what part of the population it represents.%
 \index{sampling weight}
 
 \end{itemize}
 
 
 
-\chapter{Regression}
+\chapter{Regression}%
 \label{regression}
 
 The linear least squares fit in the previous chapter is an example of
 {\bf regression}, which is the more general problem of fitting any
 kind of model to any kind of data.  This use of the term ``regression''
 is a historical accident; it is only indirectly related to the
-original meaning of the word.
-\index{model}
+original meaning of the word.%
+\index{model}%
 \index{regression}
 
 The goal of regression analysis is to describe the relationship
 between one set of variables, called the {\bf dependent variables},
 and another set of variables, called independent or {\bf
-  explanatory variables}.
-\index{explanatory variable}
+  explanatory variables}.%
+\index{explanatory variable}%
 \index{dependent variable}
 
 In the previous chapter we used mother's age as an explanatory
@@ -8189,10 +8280,10 @@ is only one dependent and one explanatory variable, that's {\bf
   simple regression}.  In this chapter, we move on to {\bf multiple
   regression}, with more than one explanatory variable.  If there is
 more than one dependent variable, that's multivariate
-regression.
-\index{birth weight}
-\index{weight!birth}
-\index{simple regression}
+regression.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{simple regression}%
 \index{multiple regression}
 
 If the relationship between the dependent and explanatory variable
@@ -8206,8 +8297,8 @@ regression model:
 where $\beta_0$ is the intercept, $\beta_1$ is the parameter
 associated with $x_1$, $\beta_2$ is the parameter associated with
 $x_2$, and $\eps$ is the residual due to random variation or other
-unknown factors.
-\index{regression model}
+unknown factors.%
+\index{regression model}%
 \index{linear regression}
 
 Given a sequence of values for $y$ and sequences for $x_1$ and $x_2$,
@@ -8216,15 +8307,15 @@ minimize the sum of $\eps^2$.  This process is called
 {\bf ordinary least squares}.  The computation is similar to {\tt
   thinkstats2.LeastSquare}, but generalized to deal with more than one
 explanatory variable.  You can find the details at
-\url{https://en.wikipedia.org/wiki/Ordinary_least_squares}
-\index{explanatory variable}
-\index{ordinary least squares}
+\url{https://en.wikipedia.org/wiki/Ordinary_least_squares}%
+\index{explanatory variable}%
+\index{ordinary least squares}%
 \index{parameter}
 
 The code for this chapter is in {\tt regression.py}.  For information
 about downloading and working with this code, see Section~\ref{code}.
 
-\section{StatsModels}
+\section{StatsModels}%
 \label{statsmodels}
 
 In the previous chapter I presented {\tt thinkstats2.LeastSquares}, an
@@ -8232,12 +8323,12 @@ implementation of simple linear regression intended to be easy to
 read.  For multiple regression we'll switch to StatsModels, a Python
 package that provides several forms of regression and other
 analyses.  If you are using Anaconda, you already have StatsModels;
-otherwise you might have to install it.
+otherwise you might have to install it.%
 \index{Anaconda}
 
 As an example, I'll run the model from the previous chapter with
-StatsModels:
-\index{StatsModels}
+StatsModels:%
+\index{StatsModels}%
 \index{model}
 
 \begin{verbatim}
@@ -8253,25 +8344,25 @@ StatsModels:
 API uses strings to identify the dependent and explanatory variables.
 It uses a syntax called {\tt patsy}; in this example, the \verb"~"
 operator separates the dependent variable on the left from the
-explanatory variables on the right.
-\index{explanatory variable}
-\index{dependent variable}
+explanatory variables on the right.%
+\index{explanatory variable}%
+\index{dependent variable}%
 \index{Patsy}
 
 {\tt smf.ols} takes the formula string and the DataFrame, {\tt live},
 and returns an OLS object that represents the model.  The name {\tt ols}
-stands for ``ordinary least squares.''
-\index{DataFrame}
-\index{model}
+stands for ``ordinary least squares.''%
+\index{DataFrame}%
+\index{model}%
 \index{ordinary least squares}
 
 The {\tt fit} method fits the model to the data and returns a
-RegressionResults object that contains the results.
+RegressionResults object that contains the results.%
 \index{RegressionResults}
 
 The results are also available as attributes.  {\tt params}
 is a Series that maps from variable names to their parameters, so we can
-get the intercept and slope like this:
+get the intercept and slope like this:%
 \index{Series}
 
 \begin{verbatim}
@@ -8280,34 +8371,35 @@ get the intercept and slope like this:
 \end{verbatim}
 
 The estimated parameters are 6.83 and 0.0175, the same as
-from {\tt LeastSquares}.
+from {\tt LeastSquares}.%
 \index{parameter}
 
 {\tt pvalues} is a Series that maps from variable names to the associated
 p-values, so we can check whether the estimated slope is statistically
-significant:
-\index{p-value}
-  \index{significant} \index{statistically significant}
+significant:%
+\index{p-value}%
+\index{significant}%
+\index{statistically significant}
 
 \begin{verbatim}
     slope_pvalue = results.pvalues['agepreg']
 \end{verbatim}
 
 The p-value associated with {\tt agepreg} is {\tt 5.7e-11}, which
-is less than $0.001$, as expected.
+is less than $0.001$, as expected.%
 \index{age}
 
 {\tt results.rsquared} contains $R^2$, which is $0.0047$.  {\tt
   results} also provides \verb"f_pvalue", which is the p-value
 associated with the model as a whole, similar to testing whether $R^2$
-is statistically significant.
-\index{model}
-\index{coefficient of determination}
+is statistically significant.%
+\index{model}%
+\index{coefficient of determination}%
 \index{r-squared}
 
 And {\tt results} provides {\tt resid}, a sequence of residuals, and
 {\tt fittedvalues}, a sequence of fitted values corresponding to
-{\tt agepreg}.
+{\tt agepreg}.%
 \index{residuals}
 
 The results object provides {\tt summary()}, which
@@ -8334,31 +8426,31 @@ which is the RMSE if you have to guess birth weights without the benefit of
 any explanatory variables.  {\tt Std(res)} is the standard deviation
 of the residuals, which is the RMSE if your guesses are informed
 by the mother's age.  As we have already seen, knowing the mother's
-age provides no substantial improvement to the predictions.
-\index{standard deviation}
-\index{birth weight}
-\index{weight!birth}
-\index{explanatory variable}
-\index{dependent variable}
-\index{RMSE}
+age provides no substantial improvement to the predictions.%
+\index{standard deviation}%
+\index{birth weight}%
+\index{weight!birth}%
+\index{explanatory variable}%
+\index{dependent variable}%
+\index{RMSE}%
 \index{predictive power}
 
 
-\section{Multiple regression}
+\section{Multiple regression}%
 \label{multiple}
 
 In Section~\ref{birth_weights} we saw that first babies tend to be
 lighter than others, and this effect is statistically significant.
 But it is a strange result because there is no obvious mechanism that
 would cause first babies to be lighter.  So we might wonder whether
-this relationship is {\bf spurious}.
-\index{multiple regression}
+this relationship is {\bf spurious}.%
+\index{multiple regression}%
 \index{spurious relationship}
 
 In fact, there is a possible explanation for this effect.  We have
 seen that birth weight depends on mother's age, and we might expect
-that mothers of first babies are younger than others.
-\index{weight}
+that mothers of first babies are younger than others.%
+\index{weight}%
 \index{age}
 
 With a few calculations we can check whether this explanation
@@ -8379,8 +8471,8 @@ diff_age = firsts.agepreg.mean() - others.agepreg.mean()
 
 The mothers of first babies are 3.59 years younger.  Running the
 linear model again, we get the change in birth weight as a function
-of age:
-\index{birth weight}
+of age:%
+\index{birth weight}%
 \index{weight!birth}
 
 \begin{verbatim}
@@ -8401,7 +8493,7 @@ So we conclude, tentatively, that the observed difference in birth
 weight can be partly explained by the difference in mother's age. 
 
 Using multiple regression, we can explore these relationships
-more systematically.
+more systematically.%
 \index{multiple regression}
 
 \begin{verbatim}
@@ -8412,8 +8504,8 @@ more systematically.
 
 The first line creates a new column named {\tt isfirst} that is
 True for first babies and false otherwise.  Then we fit a model
-using {\tt isfirst} as an explanatory variable.
-\index{model}
+using {\tt isfirst} as an explanatory variable.%
+\index{model}%
 \index{explanatory variable}
 
 Here are the results:
@@ -8430,18 +8522,18 @@ into categories, like True and False, and should not be treated
 as numbers.  The estimated parameter is the effect on birth
 weight when {\tt isfirst} is true, so the result,
 -0.125 lbs, is the difference in
-birth weight between first babies and others.  
-\index{birth weight}
-\index{weight!birth}
-\index{categorical variable}
+birth weight between first babies and others.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{categorical variable}%
 \index{boolean}
 
 The slope and the intercept are statistically significant,
 which means that they were unlikely to occur by chance, but the
 the $R^2$ value for this model is small, which means that
 {\tt isfirst} doesn't account for a substantial part of the
-variation in birth weight.
-\index{coefficient of determination}
+variation in birth weight.%
+\index{coefficient of determination}%
 \index{r-squared}
 
 The results are similar with {\tt agepreg}:
@@ -8453,8 +8545,8 @@ R^2 0.004738
 \end{verbatim}
 
 Again, the parameters are statistically significant, but
-$R^2$ is low.
-\index{coefficient of determination}
+$R^2$ is low.%
+\index{coefficient of determination}%
 \index{r-squared}
 
 These models confirm results we have already seen.  But now we
@@ -8472,26 +8564,26 @@ In the combined model, the parameter for {\tt isfirst} is smaller
 by about half, which means that part of the apparent effect of
 {\tt isfirst} is actually accounted for by {\tt agepreg}.  And
 the p-value for {\tt isfirst} is about 2.5\%, which is on the
-border of statistical significance.
-\index{p-value}
+border of statistical significance.%
+\index{p-value}%
 \index{model}
 
 $R^2$ for this model is a little higher, which indicates that the
 two variables together account for more variation in birth weight
-than either alone (but not by much).
-\index{birth weight}
-\index{weight!birth}
-\index{coefficient of determination}
+than either alone (but not by much).%
+\index{birth weight}%
+\index{weight!birth}%
+\index{coefficient of determination}%
 \index{r-squared}
 
 
-\section{Nonlinear relationships}
+\section{Nonlinear relationships}%
 \label{nonlinear}
 
 Remembering that the contribution of {\tt agepreg} might be nonlinear,
 we might consider adding a variable to capture more of this
 relationship.  One option is to create a column, {\tt agepreg2},
-that contains the squares of the ages:
+that contains the squares of the ages:%
 \index{nonlinear}
 
 \begin{verbatim}
@@ -8512,26 +8604,27 @@ R^2 0.007462
 
 The parameter of {\tt agepreg2} is negative, so the parabola
 curves downward, which is consistent with the shape of the lines
-in Figure~\ref{linear2}.
+in Figure~\ref{linear2}.%
 \index{parabola}
 
 The quadratic model of {\tt agepreg} accounts for more of the
 variability in birth weight; the parameter for {\tt isfirst}
-is smaller in this model, and no longer statistically significant.
-\index{birth weight}
-\index{weight!birth}
-\index{quadratic model}
-\index{model}
-  \index{significant} \index{statistically significant}
+is smaller in this model, and no longer statistically significant.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{quadratic model}%
+\index{model}%
+\index{significant}%
+\index{statistically significant}
 
 Using computed variables like {\tt agepreg2} is a common way to
 fit polynomials and other functions to data.  
 This process is still considered linear
 regression, because the dependent variable is a linear function of
 the explanatory variables, regardless of whether some variables
-are nonlinear functions of others.
-\index{explanatory variable}
-\index{dependent variable}
+are nonlinear functions of others.%
+\index{explanatory variable}%
+\index{dependent variable}%
 \index{nonlinear}
 
 The following table summarizes the results of these regressions:
@@ -8550,27 +8643,27 @@ Model 4 & -0.0504 (0.11) & 0.112 * & -0.00185 * & 0.0075 \\
 The columns in this table are the explanatory variables and
 the coefficient of determination, $R^2$.  Each entry is an estimated
 parameter and either a p-value in parentheses or an asterisk to
-indicate a p-value less that 0.001.
-\index{p-value}
-\index{coefficient of determination}
-\index{r-squared}
+indicate a p-value less that 0.001.%
+\index{p-value}%
+\index{coefficient of determination}%
+\index{r-squared}%
 \index{explanatory variable}
 
 We conclude that the apparent difference in birth weight
 is explained, at least in part, by the difference in mother's age.
 When we include mother's age in the model, the effect of
 {\tt isfirst} gets smaller, and the remaining effect might be
-due to chance.
+due to chance.%
 \index{age}
 
 In this example, mother's age acts as a {\bf control variable};
 including {\tt agepreg} in the model ``controls for'' the
 difference in age between first-time mothers and others, making
-it possible to isolate the effect (if any) of {\tt isfirst}. 
+it possible to isolate the effect (if any) of {\tt isfirst}.%
 \index{control variable}
 
 
-\section{Data mining}
+\section{Data mining}%
 \label{mining}
 
 So far we have used regression models for explanation; for example,
@@ -8578,17 +8671,17 @@ in the previous section we discovered that an apparent difference
 in birth weight is actually due to a difference in mother's age.
 But the $R^2$ values of those models is very low, which means that
 they have little predictive power.  In this section we'll try to
-do better.
-\index{birth weight}
-\index{weight!birth}
-\index{regression model}
-\index{coefficient of determination}
+do better.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{regression model}%
+\index{coefficient of determination}%
 \index{r-squared}
 
 Suppose one of your co-workers is expecting a baby and
 there is an office pool to guess the baby's birth weight (if you are
 not familiar with betting pools, see
-\url{https://en.wikipedia.org/wiki/Betting_pool}).
+\url{https://en.wikipedia.org/wiki/Betting_pool}).%
 \index{betting pool}
 
 Now suppose that you {\em really\/} want to win the pool.  What could
@@ -8596,7 +8689,7 @@ you do to improve your chances?  Well,
 the NSFG dataset includes 244 variables about each pregnancy and another
 3087 variables about each respondent.  Maybe some of those variables
 have predictive power.  To find out which ones are most useful,
-why not try them all?
+why not try them all?%
 \index{NSFG}
 
 Testing the variables in the pregnancy table is easy, but in order to
@@ -8604,14 +8697,14 @@ use the variables in the respondent table, we have to match up each
 pregnancy with a respondent.  In theory we could iterate through the
 rows of the pregnancy table, use the {\tt caseid} to find the
 corresponding respondent, and copy the values from the
-correspondent table into the pregnancy table.  But that would be slow.
-\index{join}
+correspondent table into the pregnancy table.  But that would be slow.%
+\index{join}%
 \index{SQL}
 
 A better option is to recognize this process as a {\bf join} operation
 as defined in SQL and other relational database languages (see
 \url{https://en.wikipedia.org/wiki/Join_(SQL)}).  Join is implemented
-as a DataFrame method, so we can perform the operation like this:
+as a DataFrame method, so we can perform the operation like this:%
 \index{DataFrame}
 
 \begin{verbatim}
@@ -8623,7 +8716,7 @@ as a DataFrame method, so we can perform the operation like this:
 
 The first line selects records for pregnancies longer than 30 weeks,
 assuming that the office pool is formed several weeks before the
-due date.
+due date.%
 \index{betting pool}
 
 The next line reads the respondent file.  The result is a DataFrame
@@ -8640,13 +8733,13 @@ so we have to provide {\tt rsuffix}, which is a string that will be
 appended to the names of overlapping columns from the right table.
 For example, both tables have a column named {\tt race} that encodes
 the race of the respondent.  The result of the join contains two
-columns named {\tt race} and \verb"race_r".
+columns named {\tt race} and \verb"race_r".%
 \index{race}
 
 The pandas implementation is fast.  Joining the NSFG tables takes
 less than a second on an ordinary desktop computer.
-Now we can start testing variables.
-\index{pandas}
+Now we can start testing variables.%
+\index{pandas}%
 \index{join}
 
 \begin{verbatim}
@@ -8670,29 +8763,29 @@ Now we can start testing variables.
 
 For each variable we construct a model, compute $R^2$, and append
 the results to a list.  The models all include {\tt agepreg}, since
-we already know that it has some predictive power.
-\index{model}
-\index{coefficient of determination}
+we already know that it has some predictive power.%
+\index{model}%
+\index{coefficient of determination}%
 \index{r-squared}
 
 I check that each explanatory variable has some variability; otherwise
 the results of the regression are unreliable.  I also check the number
 of observations for each model.  Variables that contain a large number
-of {\tt nan}s are not good candidates for prediction.
-\index{explanatory variable}
+of {\tt nan}s are not good candidates for prediction.%
+\index{explanatory variable}%
 \index{NaN}
 
 For most of these variables, we haven't done any cleaning.  Some of them
 are encoded in ways that don't work very well for linear regression.
 As a result, we might overlook some variables that would be useful if
-they were cleaned properly.  But maybe we will find some good candidates.
+they were cleaned properly.  But maybe we will find some good candidates.%
 \index{cleaning}
 
 
 \section{Prediction}
 
 The next step is to sort the results and select the variables that
-yield the highest values of $R^2$.
+yield the highest values of $R^2$.%
 \index{prediction}
 
 \begin{verbatim}
@@ -8703,20 +8796,20 @@ yield the highest values of $R^2$.
 
 The first variable on the list is \verb"totalwgt_lb",
 followed by \verb"birthwgt_lb".  Obviously, we can't use birth
-weight to predict birth weight.
-\index{birth weight}
+weight to predict birth weight.%
+\index{birth weight}%
 \index{weight!birth}
 
 Similarly {\tt prglngth} has useful predictive power, but for the
 office pool we assume pregnancy length (and the related variables)
-are not known yet.
-\index{predictive power}
+are not known yet.%
+\index{predictive power}%
 \index{pregnancy length}
 
 The first useful predictive variable is {\tt babysex} which indicates
 whether the baby is male or female.  In the NSFG dataset, boys are
 about 0.3 lbs heavier.  So, assuming that the sex of the baby is
-known, we can use it for prediction.
+known, we can use it for prediction.%
 \index{sex}
 
 Next is {\tt race}, which indicates whether the respondent is white,
@@ -8725,14 +8818,14 @@ In datasets like the NSFG, race is correlated with many other
 variables, including income and other socioeconomic factors.  In a
 regression model, race acts as a {\bf proxy variable},
 so apparent correlations with race are often caused, at least in
-part, by other factors.
-\index{explanatory variable}
+part, by other factors.%
+\index{explanatory variable}%
 \index{race}
 
 The next variable on the list is {\tt nbrnaliv}, which indicates
 whether the pregnancy yielded multiple births.  Twins and triplets
 tend to be smaller than other babies, so if we know whether our
-hypothetical co-worker is expecting twins, that would help.
+hypothetical co-worker is expecting twins, that would help.%
 \index{multiple birth}
 
 Next on the list is {\tt paydu}, which indicates whether the
@@ -8740,10 +8833,10 @@ respondent owns her home.  It is one of several income-related
 variables that turn out to be predictive.  In datasets like the NSFG,
 income and wealth are correlated with just about everything.  In this
 example, income is related to diet, health, health care, and other
-factors likely to affect birth weight.
-\index{birth weight}
-\index{weight!birth}
-\index{income}
+factors likely to affect birth weight.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{income}%
 \index{wealth}
 
 Some of the other variables on the list are things that would not
@@ -8757,13 +8850,13 @@ times you start with data and go looking for possible theories.
 The second approach, which this section demonstrates, is
 called {\bf data mining}.  An advantage of data mining is that it
 can discover unexpected patterns.  A hazard is that many of the
-patterns it discovers are either random or spurious.
-\index{theory}
+patterns it discovers are either random or spurious.%
+\index{theory}%
 \index{data mining}
 
 Having identified potential explanatory variables, I tested a few
-models and settled on this one:
-\index{model}
+models and settled on this one:%
+\index{model}%
 \index{explanatory variable}
 
 \begin{verbatim}
@@ -8774,13 +8867,13 @@ models and settled on this one:
 
 This formula uses some syntax we have not seen yet:
 {\tt C(race)} tells the formula parser (Patsy) to treat race as a
-categorical variable, even though it is encoded numerically.
-\index{Patsy}
+categorical variable, even though it is encoded numerically.%
+\index{Patsy}%
 \index{categorical variable}
 
 The encoding for {\tt babysex} is 1 for male, 2 for female; writing
 {\tt babysex==1} converts it to boolean, True for male and false for
-female.
+female.%
 \index{boolean}
 
 Similarly {\tt nbrnaliv>1} is True for multiple births and 
@@ -8788,7 +8881,7 @@ Similarly {\tt nbrnaliv>1} is True for multiple births and
 
 {\tt totincr} is encoded numerically from 1-14, with each increment
 representing about \$5000 in annual income.  So we can treat these
-values as numerical, expressed in units of \$5000.
+values as numerical, expressed in units of \$5000.%
 \index{income}
 
 Here are the results of the model:
@@ -8807,19 +8900,19 @@ totincr                 0.0122  (0.00188)
 The estimated parameters for race are larger than I expected,
 especially since we control for income.  The encoding
 is 1 for black, 2 for white, and 3 for other.  Babies of black
-mothers are lighter than babies of other races by 0.27--0.36 lbs.
-\index{control variable}
+mothers are lighter than babies of other races by 0.27--0.36 lbs.%
+\index{control variable}%
 \index{race}
 
 As we've already seen, boys are heavier by about 0.3 lbs;
-twins and other multiplets are lighter by 1.4 lbs.
+twins and other multiplets are lighter by 1.4 lbs.%
 \index{weight}
 
 People who own their homes have heavier babies by about 0.12 lbs,
 even when we control for income.  The parameter for mother's
 age is smaller than what we saw in Section~\ref{multiple}, which
 suggests that some of the other variables are correlated with
-age, probably including {\tt paydu} and {\tt totincr}.
+age, probably including {\tt paydu} and {\tt totincr}.%
 \index{income}
 
 All of these variables are statistically significant, some with
@@ -8827,12 +8920,13 @@ very low p-values, but
 $R^2$ is only 0.06, still quite small.
 RMSE without using the model is 1.27 lbs; with the model it drops
 to 1.23.  So your chance of winning the pool is not substantially
-improved.  Sorry!
-\index{p-value}
-\index{model}
-\index{coefficient of determination}
-\index{r-squared}
-  \index{significant} \index{statistically significant}
+improved.  Sorry!%
+\index{p-value}%
+\index{model}%
+\index{coefficient of determination}%
+\index{r-squared}%
+\index{significant}%
+\index{statistically significant}
 
 
 
@@ -8840,19 +8934,19 @@ improved.  Sorry!
 
 In the previous examples, some of the explanatory variables were
 numerical and some categorical (including boolean).  But the dependent
-variable was always numerical.
-\index{explanatory variable}
-\index{dependent variable}
+variable was always numerical.%
+\index{explanatory variable}%
+\index{dependent variable}%
 \index{categorical variable}
 
 Linear regression can be generalized to handle other kinds of
 dependent variables.  If the dependent variable is boolean, the
 generalized model is called {\bf logistic regression}.  If the dependent
 variable is an integer count, it's called {\bf Poisson
-regression}.
-\index{model}
-\index{logistic regression}
-\index{Poisson regression}
+regression}.%
+\index{model}%
+\index{logistic regression}%
+\index{Poisson regression}%
 \index{boolean}
 
 As an example of logistic regression, let's consider a variation
@@ -8862,8 +8956,8 @@ a friend of yours is pregnant and you want to predict whether the
 baby is a boy or a girl.  You could use data from the NSFG to find
 factors that affect the ``sex ratio'', which is conventionally
 defined to be the probability
-of having a boy.
-\index{betting pool}
+of having a boy.%
+\index{betting pool}%
 \index{sex}
 
 If you encode the dependent variable numerically, for example 0 for a
@@ -8875,29 +8969,29 @@ this:
 %
 Where $y$ is the dependent variable, and $x_1$ and $x_2$ are
 explanatory variables.  Then we could find the parameters that
-minimize the residuals.
-\index{regression model}
-\index{explanatory variable}
-\index{dependent variable}
+minimize the residuals.%
+\index{regression model}%
+\index{explanatory variable}%
+\index{dependent variable}%
 \index{ordinary least squares}
 
 The problem with this approach is that it produces predictions that
 are hard to interpret.  Given estimated parameters and values for
 $x_1$ and $x_2$, the model might predict $y=0.5$, but the only
-meaningful values of $y$ are 0 and 1.
+meaningful values of $y$ are 0 and 1.%
 \index{parameter}
 
 It is tempting to interpret a result like that as a probability; for
 example, we might say that a respondent with particular values of
 $x_1$ and $x_2$ has a 50\% chance of having a boy.  But it is also
 possible for this model to predict $y=1.1$ or $y=-0.1$, and those
-are not valid probabilities.
+are not valid probabilities.%
 \index{probability}
 
 Logistic regression avoids this problem by expressing predictions in
 terms of {\bf odds} rather than probabilities.  If you are not
 familiar with odds, ``odds in favor'' of an event is the ratio of the
-probability it will occur to the probability that it will not.
+probability it will occur to the probability that it will not.%
 \index{odds}
 
 So if I think my team has a 75\% chance of winning, I would
@@ -8923,7 +9017,7 @@ Logistic regression is based on the following model:
 \[ \log o = \beta_0 + \beta_1 x_1 + \beta_2 x_2 + \eps \]
 %
 Where $o$ is the odds in favor of a particular outcome; in the
-example, $o$ would be the odds of having a boy.
+example, $o$ would be the odds of having a boy.%
 \index{regression model}
 
 Suppose we have estimated the parameters $\beta_0$, $\beta_1$, and
@@ -8937,7 +9031,7 @@ $\log o$, and then convert to a probability:
 \end{verbatim}
 
 So in the office pool scenario we could compute the predictive
-probability of having a boy.  But how do we estimate the parameters?
+probability of having a boy.  But how do we estimate the parameters?%
 \index{parameter}
 
 
@@ -8945,14 +9039,14 @@ probability of having a boy.  But how do we estimate the parameters?
 
 Unlike linear regression, logistic regression does not have a
 closed form solution, so it is solved by guessing an initial
-solution and improving it iteratively.
-\index{logistic regression}
+solution and improving it iteratively.%
+\index{logistic regression}%
 \index{closed form}
 
 The usual goal is to find the maximum-likelihood estimate (MLE),
 which is the set of parameters that maximizes the likelihood of the
-data.  For example, suppose we have the following data:
-\index{MLE}
+data.  For example, suppose we have the following data:%
+\index{MLE}%
 \index{maximum likelihood estimator}
 
 \begin{verbatim}
@@ -8975,7 +9069,7 @@ Then for each row we can compute \verb"log_o":
 [-1.5 -0.4 -0.4  2.4]
 \end{verbatim}
 
-And convert from log odds to probabilities:
+And convert from log odds to probabilities:%
 \index{log odds}
 
 \begin{verbatim}
@@ -8993,7 +9087,7 @@ The likelihood of an outcome is {\tt p} when {\tt y==1} and {\tt 1-p}
 when {\tt y==0}.  For example, if we think the probability of a boy is
 0.8 and the outcome is a boy, the likelihood is 0.8; if
 the outcome is a girl, the likelihood is 0.2.  We can compute that
-like this:
+like this:%
 \index{likelihood}
 
 \begin{verbatim}
@@ -9012,20 +9106,20 @@ For these values of {\tt beta}, the likelihood of the data is 0.18.
 The goal of logistic regression is to find parameters that maximize
 this likelihood.  To do that, most statistics packages use an
 iterative solver like Newton's method (see
-\url{https://en.wikipedia.org/wiki/Logistic_regression#Model_fitting}).
-\index{Newton's method}
+\url{https://en.wikipedia.org/wiki/Logistic_regression#Model_fitting}).%
+\index{Newton's method}%
 \index{iterative solver}
 
 
-\section{Implementation}
+\section{Implementation}%
 \label{implementation}
 
 StatsModels provides an implementation of logistic regression
 called {\tt logit}, named for the function that converts from
 probability to log odds.  To demonstrate its use, I'll look for
-variables that affect the sex ratio.
-\index{StatsModels}
-\index{sex ratio}
+variables that affect the sex ratio.%
+\index{StatsModels}%
+\index{sex ratio}%
 \index{logit function}
 
 Again, I load the NSFG data and select pregnancies longer than
@@ -9038,9 +9132,9 @@ Again, I load the NSFG data and select pregnancies longer than
 
 {\tt logit} requires the dependent variable to be binary (rather than
 boolean), so I create a new column named {\tt boy}, using {\tt
-  astype(int)} to convert to binary integers:
-\index{dependent variable}
-\index{boolean}
+  astype(int)} to convert to binary integers:%
+\index{dependent variable}%
+\index{boolean}%
 \index{binary}
 
 \begin{verbatim}
@@ -9050,8 +9144,8 @@ boolean), so I create a new column named {\tt boy}, using {\tt
 Factors that have been found to affect sex ratio include parents'
 age, birth order, race, and social status.  We can use logistic
 regression to see if these effects appear in the NSFG data.  I'll
-start with the mother's age:
-\index{age}
+start with the mother's age:%
+\index{age}%
 \index{race}
 
 \begin{verbatim}
@@ -9069,14 +9163,14 @@ that represents the model.  It contains attributes called
 variable}, another name for the dependent variable,
 and the {\bf exogenous variables}, another name for the
 explanatory variables.  Since they are NumPy arrays, it is
-sometimes convenient to convert them to DataFrames:
-\index{NumPy}
-\index{pandas}
-\index{DataFrame}
-\index{explanatory variable}
-\index{dependent variable}
-\index{exogenous variable}
-\index{endogenous variable}
+sometimes convenient to convert them to DataFrames:%
+\index{NumPy}%
+\index{pandas}%
+\index{DataFrame}%
+\index{explanatory variable}%
+\index{dependent variable}%
+\index{exogenous variable}%
+\index{endogenous variable}%
 \index{Patsy}
 
 \begin{verbatim}
@@ -9097,18 +9191,18 @@ R^2 6.144e-06
 The parameter of {\tt agepreg} is positive, which suggests that
 older mothers are more likely to have boys, but the p-value is
 0.783, which means that the apparent effect could easily be due
-to chance.
-\index{p-value}
+to chance.%
+\index{p-value}%
 \index{age}
 
 The coefficient of determination, $R^2$, does not apply to logistic
 regression, but there are several alternatives that are used
 as ``pseudo $R^2$ values.''  These values can be useful for comparing
 models.  For example, here's a model that includes several factors
-believed to be associated with sex ratio:
-\index{model}
-\index{coefficient of determination}
-\index{r-squared}
+believed to be associated with sex ratio:%
+\index{model}%
+\index{coefficient of determination}%
+\index{r-squared}%
 \index{pseudo r-squared}
 
 \begin{verbatim}
@@ -9119,7 +9213,7 @@ believed to be associated with sex ratio:
 
 Along with mother's age, this model includes father's age at
 birth ({\tt hpagelb}), birth order ({\tt birthord}), and
-race as a categorical variable.  Here are the results:
+race as a categorical variable.  Here are the results:%
 \index{categorical variable}
 
 \begin{verbatim}
@@ -9134,19 +9228,20 @@ R^2 0.000144
 
 None of the estimated parameters are statistically significant.  The
 pseudo-$R^2$ value is a little higher, but that could be due to
-chance.
-\index{pseudo r-squared}
-  \index{significant} \index{statistically significant}
+chance.%
+\index{pseudo r-squared}%
+\index{significant}%
+\index{statistically significant}
 
 
-\section{Accuracy}
+\section{Accuracy}%
 \label{accuracy}
 
 In the office pool scenario,
 we are most interested in the accuracy of the model:
 the number of successful predictions, compared with what we would
-expect by chance.
-\index{model}
+expect by chance.%
+\index{model}%
 \index{accuracy}
 
 In the NSFG data, there are more boys than girls, so the baseline
@@ -9172,9 +9267,9 @@ Here's how we compute the accuracy of the model:
 {\tt results.predict} returns a NumPy array of probabilities, which we
 round off to 0 or 1.  Multiplying by {\tt actual}
 yields 1 if we predict a boy and get it right, 0 otherwise.  So,
-\verb"true_pos" indicates ``true positives''.
-\index{NumPy}
-\index{true positive}
+\verb"true_pos" indicates ``true positives''.%
+\index{NumPy}%
+\index{true positive}%
 \index{true negative}
 
 Similarly, \verb"true_neg" indicates the cases where we guess ``girl''
@@ -9187,7 +9282,7 @@ and get it right.  Accuracy is the fraction of correct guesses:
 The result is 0.512, slightly better than the
 baseline, 0.507.  But, you should not take this result too seriously.
 We used the same data to build and test the model, so the model
-may not have predictive power on new data.
+may not have predictive power on new data.%
 \index{model}
 
 Nevertheless, let's use the model to make a prediction for the office
@@ -9203,7 +9298,7 @@ her husband is 39, and they are expecting their third child:
 To invoke {\tt results.predict} for a new case, you have to construct
 a DataFrame with a column for each variable in the model.  The result
 in this case is 0.52, so you should guess ``boy.''  But if the model
-improves your chances of winning, the difference is very small.
+improves your chances of winning, the difference is very small.%
 \index{DataFrame}
 
 
@@ -9218,8 +9313,8 @@ participating in an office pool to predict the date of birth.
 Assuming that bets are placed during the 30th week of pregnancy, what
 variables could you use to make the best prediction?  You should limit
 yourself to variables that are known before the birth, and likely to
-be available to the people in the pool.
-\index{betting pool}
+be available to the people in the pool.%
+\index{betting pool}%
 \index{date of birth}
 
 \end{exercise}
@@ -9229,19 +9324,20 @@ be available to the people in the pool.
 The Trivers-Willard hypothesis suggests that for many mammals the
 sex ratio depends on ``maternal condition''; that is,
 factors like the mother's age, size, health, and social status.
-See \url{https://en.wikipedia.org/wiki/Trivers-Willard_hypothesis}
-\index{Trivers-Willard hypothesis}
+See \url{https://en.wikipedia.org/wiki/Trivers-Willard_hypothesis}%
+\index{Trivers-Willard hypothesis}%
 \index{sex ratio}
 
 Some studies have shown this effect among humans, but results are
 mixed.  In this chapter we tested some variables related to these
 factors, but didn't find any with a statistically significant effect
-on sex ratio.
-  \index{significant} \index{statistically significant}
+on sex ratio.%
+\index{significant}%
+\index{statistically significant}
 
 As an exercise, use a data mining approach to test the other variables
 in the pregnancy and respondent files.  Can you find any factors with
-a substantial effect?  
+a substantial effect?%
 \index{data mining}
 
 \end{exercise}
@@ -9252,8 +9348,8 @@ If the quantity you want to predict is a count, you can use Poisson
 regression, which is implemented in StatsModels with a function called
 {\tt poisson}.  It works the same way as {\tt ols} and {\tt logit}.
 As an exercise, let's use it to predict how many children a woman
-has born; in the NSFG dataset, this variable is called {\tt numbabes}.
-\index{StatsModels}
+has born; in the NSFG dataset, this variable is called {\tt numbabes}.%
+\index{StatsModels}%
 \index{Poisson regression}
 
 Suppose you meet a woman who is 35 years old, black, and a college
@@ -9268,8 +9364,8 @@ multinomial logistic regression, which is implemented in StatsModels
 with a function called {\tt mnlogit}.  As an exercise, let's use it to
 guess whether a woman is married, cohabitating, widowed, divorced,
 separated, or never married; in the NSFG dataset, marital status is
-encoded in a variable called {\tt rmarital}.
-\index{categorical variable}
+encoded in a variable called {\tt rmarital}.%
+\index{categorical variable}%
 \index{marital status}
 
 Suppose you meet a woman who is 25 years old, white, and a high
@@ -9285,72 +9381,72 @@ What is the probability that she is married, cohabitating, etc?
 \begin{itemize}
 
 \item regression: One of several related processes for estimating parameters
-that fit a model to data.
+that fit a model to data.%
 \index{regression}
 
 \item dependent variables: The variables in a regression model we would
-like to predict.  Also known as endogenous variables.
-\index{dependent variable}
+like to predict.  Also known as endogenous variables.%
+\index{dependent variable}%
 \index{endogenous variable}
 
 \item explanatory variables: The variables used to predict or explain
 the dependent variables.  Also known as independent, or exogenous,
-variables.
-\index{explanatory variable}
+variables.%
+\index{explanatory variable}%
 \index{exogenous variable}
 
 \item simple regression: A regression with only one dependent and
-one explanatory variable.
+one explanatory variable.%
 \index{simple regression}
 
 \item multiple regression: A regression with multiple explanatory
-variables, but only one dependent variable.
+variables, but only one dependent variable.%
 \index{multiple regression}
 
-\item linear regression: A regression based on a linear model.
+\item linear regression: A regression based on a linear model.%
 \index{linear regression}
 
 \item ordinary least squares: A linear regression that estimates
-parameters by minimizing the squared error of the residuals.
+parameters by minimizing the squared error of the residuals.%
 \index{ordinary least squares}
 
 \item spurious relationship: A relationship between two variables that is 
 caused by a statistical artifact or a factor, not included in the
-model, that is related to both variables.
+model, that is related to both variables.%
 \index{spurious relationship}
 
 \item control variable: A variable included in a regression to
-eliminate or ``control for'' a spurious relationship.
+eliminate or ``control for'' a spurious relationship.%
 \index{control variable}
 
 \item proxy variable: A variable that contributes information to
 a regression model indirectly because of a relationship with another
-factor, so it acts as a proxy for that factor.
+factor, so it acts as a proxy for that factor.%
 \index{proxy variable}
 
 \item categorical variable: A variable that can have one of a
-discrete set of unordered values.
+discrete set of unordered values.%
 \index{categorical variable}
 
 \item join: An operation that combines data from two DataFrames
-using a key to match up rows in the two frames.
-\index{join}
+using a key to match up rows in the two frames.%
+\index{join}%
 \index{DataFrame}
 
 \item data mining: An approach to finding relationships between
-variables by testing a large number of models.
+variables by testing a large number of models.%
 \index{data mining}
 
 \item logistic regression: A form of regression used when the
-dependent variable is boolean.
+dependent variable is boolean.%
 \index{logistic regression}
 
 \item Poisson regression: A form of regression used when the
-dependent variable is a non-negative integer, usually a count.
+dependent variable is a non-negative integer, usually a count.%
 \index{Poisson regression}
 
 \item odds: An alternative way of representing a probability, $p$, as
-  the ratio of the probability and its complement, $p / (1-p)$.
+  the ratio of the probability and its complement, $p / (1-p)$.%
 \index{odds}
 
 \end{itemize}
@@ -9362,8 +9458,8 @@ dependent variable is a non-negative integer, usually a count.
 A {\bf time series} is a sequence of measurements from a system that
 varies in time.  One famous example is the ``hockey stick graph'' that
 shows global average temperature over time (see
-\url{https://en.wikipedia.org/wiki/Hockey_stick_graph}).
-\index{time series}
+\url{https://en.wikipedia.org/wiki/Hockey_stick_graph}).%
+\index{time series}%
 \index{hockey stick graph}
 
 The example I work with in this chapter comes from Zachary M. Jones, a
@@ -9375,8 +9471,8 @@ price, quantity, quality, and location of cannabis transactions
 (\url{http://www.priceofweed.com/}).  The goal of his project is to
 investigate the effect of policy decisions, like legalization, on
 markets.  I find this project appealing because it is an example that
-uses data to address important political questions, like drug policy.
-\index{Price of Weed}
+uses data to address important political questions, like drug policy.%
+\index{Price of Weed}%
 \index{cannabis}
 
 I hope you will
@@ -9384,7 +9480,7 @@ find this chapter interesting, but I'll take this opportunity to
 reiterate the importance of maintaining a professional attitude to
 data analysis.  Whether and which drugs should be illegal are
 important and difficult public policy questions; our decisions should
-be informed by accurate data reported honestly.
+be informed by accurate data reported honestly.%
 \index{ethics}
 
 The code for this chapter is in {\tt timeseries.py}.  For information
@@ -9396,8 +9492,8 @@ about downloading and working with this code, see Section~\ref{code}.
 The data I downloaded from
 Mr. Jones's site is in the repository for this book.
 The following code reads it into a
-pandas DataFrame:
-\index{pandas}
+pandas DataFrame:%
+\index{pandas}%
 \index{DataFrame}
 
 \begin{verbatim}
@@ -9405,7 +9501,7 @@ pandas DataFrame:
 \end{verbatim}
 
 \verb"parse_dates" tells \verb"read_csv" to interpret values in column 5
-as dates and convert them to NumPy {\tt datetime64} objects.
+as dates and convert them to NumPy {\tt datetime64} objects.%
 \index{NumPy}
 
 The DataFrame has a row for each reported transaction and 
@@ -9417,7 +9513,7 @@ the following columns:
 
 \item state: two-letter state abbreviation.
 
-\item price: price paid in dollars.
+\item price: price paid in dollars.%
 \index{price}
 
 \item amount: quantity purchased in grams.
@@ -9441,8 +9537,8 @@ as a time series.  But the events are not equally spaced in time; the
 number of transactions reported each day varies from 0 to several
 hundred.  Many methods used to analyze time series require the
 measurements to be equally spaced, or at least things are simpler if
-they are.
-\index{transaction}
+they are.%
+\index{transaction}%
 \index{equally spaced data}
 
 In order to demonstrate these methods, I divide the dataset
@@ -9463,7 +9559,9 @@ def GroupByQualityAndDay(transactions):
 {\tt groups}; used in a for loop, it iterates the names of the groups
 and the DataFrames that represent them.  Since the values of {\tt
   quality} are {\tt low}, {\tt medium}, and {\tt high}, we get three
-groups with those names.  \index{DataFrame} \index{groupby}
+groups with those names.%
+\index{DataFrame}%
+\index{groupby}
 
 The loop iterates through the groups and calls {\tt GroupByDay},
 which computes the daily average price and returns a new DataFrame:
@@ -9483,7 +9581,7 @@ def GroupByDay(transactions, func=np.mean):
 
 The parameter, {\tt transactions}, is a DataFrame that contains
 columns {\tt date} and {\tt ppg}.  We select these two
-columns, then group by {\tt date}.
+columns, then group by {\tt date}.%
 \index{groupby}
 
 The result, {\tt grouped}, is a map from each date to a DataFrame that
@@ -9491,7 +9589,7 @@ contains prices reported on that date.  {\tt aggregate} is a
 GroupBy method that iterates through the groups and applies a
 function to each column of the group; in this case there is only one
 column, {\tt ppg}.  So the result of {\tt aggregate} is a DataFrame
-with one row for each date and one column, {\tt ppg}.
+with one row for each date and one column, {\tt ppg}.%
 \index{aggregate}
 
 Dates in these DataFrames are stored as NumPy {\tt datetime64}
@@ -9500,12 +9598,12 @@ For some of the analyses coming up, it will be convenient to
 work with time in more human-friendly units, like years.  So
 {\tt GroupByDay} adds a column named {\tt date} by copying
 the {\tt index}, then adds {\tt years}, which contains the number
-of years since the first transaction as a floating-point number.
-\index{NumPy}
+of years since the first transaction as a floating-point number.%
+\index{NumPy}%
 \index{datetime64}
 
 The resulting DataFrame has columns {\tt ppg}, {\tt date}, and
-{\tt years}.
+{\tt years}.%
 \index{DataFrame}
 
 
@@ -9513,8 +9611,8 @@ The resulting DataFrame has columns {\tt ppg}, {\tt date}, and
 
 The result from {\tt GroupByQualityAndDay} is a map from each quality
 to a DataFrame of daily prices.  Here's the code I use to plot
-the three time series:
-\index{DataFrame}
+the three time series:%
+\index{DataFrame}%
 \index{visualization}
 
 \begin{verbatim}
@@ -9535,20 +9633,20 @@ make three subplots laid out in three rows.  The loop iterates
 through the DataFrames and creates a scatter plot for each.  It is
 common to plot time series with line segments between the points,
 but in this case there are many data points and prices are highly
-variable, so adding lines would not help.
+variable, so adding lines would not help.%
 \index{thinkplot}
 
 Since the labels on the x-axis are dates, I use {\tt pyplot.xticks}
-to rotate the ``ticks'' 30 degrees, making them more readable.
-\index{pyplot}
-\index{ticks}
+to rotate the ``ticks'' 30 degrees, making them more readable.%
+\index{pyplot}%
+\index{ticks}%
 \index{xticks}
 
 \begin{figure}
 % timeseries.py
 \centerline{\includegraphics[width=3.5in]{figs/timeseries1.pdf}}
 \caption{Time series of daily price per gram for high, medium, and low
-quality cannabis.}
+quality cannabis.}%
 \label{timeseries1}
 \end{figure}
 
@@ -9556,7 +9654,7 @@ Figure~\ref{timeseries1} shows the result.  One apparent feature in
 these plots is a gap around November 2013.  It's possible that data
 collection was not active during this time, or the data might not
 be available.  We will consider ways to deal with this missing data
-later.
+later.%
 \index{missing values}
 
 Visually, it looks like the price of high quality cannabis is
@@ -9564,20 +9662,20 @@ declining during this period, and the price of medium quality is
 increasing.  The price of low quality might also be increasing, but it
 is harder to tell, since it seems to be more volatile.  Keep in mind
 that quality data is reported by volunteers, so trends over time
-might reflect changes in how participants apply these labels.
+might reflect changes in how participants apply these labels.%
 \index{price}
 
 
-\section{Linear regression}
+\section{Linear regression}%
 \label{timeregress}
 
 Although there are methods specific to time series analysis, for many
 problems a simple way to get started is by applying general-purpose
 tools like linear regression.  The following function takes a
 DataFrame of daily prices and computes a least squares fit, returning
-the model and results objects from StatsModels:
-\index{DataFrame}
-\index{StatsModels}
+the model and results objects from StatsModels:%
+\index{DataFrame}%
+\index{StatsModels}%
 \index{linear regression}
 
 \begin{verbatim}
@@ -9613,17 +9711,19 @@ The estimated slopes indicate that the price of high quality cannabis
 dropped by about 71 cents per year during the observed interval; for
 medium quality it increased by 28 cents per year, and for low quality
 it increased by 57 cents per year.  These estimates are all
-statistically significant with very small p-values.
-\index{p-value}
-  \index{significant} \index{statistically significant}
+statistically significant with very small p-values.%
+\index{p-value}%
+\index{significant}%
+\index{statistically significant}
 
 The $R^2$ value for high quality cannabis is 0.44, which means
 that time as an explanatory variable accounts for 44\% of the observed
 variability in price.  For the other qualities, the change in price
 is smaller, and variability in prices is higher, so the values
-of $R^2$ are smaller (but still statistically significant).
-\index{explanatory variable}
-  \index{significant} \index{statistically significant}
+of $R^2$ are smaller (but still statistically significant).%
+\index{explanatory variable}%
+\index{significant}%
+\index{statistically significant}
 
 The following code plots the observed prices and the fitted values:
 
@@ -9637,27 +9737,27 @@ def PlotFittedValues(model, results, label=''):
 
 As we saw in Section~\ref{implementation}, {\tt model} contains
 {\tt exog} and {\tt endog}, NumPy arrays with the exogenous
-(explanatory) and endogenous (dependent) variables.
-\index{NumPy}
-\index{explanatory variable}
-\index{dependent variable}
-\index{exogenous variable}
+(explanatory) and endogenous (dependent) variables.%
+\index{NumPy}%
+\index{explanatory variable}%
+\index{dependent variable}%
+\index{exogenous variable}%
 \index{endogenous variable}
 
 \begin{figure}
 % timeseries.py
 \centerline{\includegraphics[height=2.5in]{figs/timeseries2.pdf}}
 \caption{Time series of daily price per gram for high quality cannabis,
-and a linear least squares fit.}
+and a linear least squares fit.}%
 \label{timeseries2}
 \end{figure}
 
 {\tt PlotFittedValues} makes a scatter plot of the data points and a line
 plot of the fitted values.  Figure~\ref{timeseries2} shows the results
 for high quality cannabis.  The model seems like a good linear fit
-for the data; nevertheless, linear regression is not the most 
-appropriate choice for this data:
-\index{model}
+for the data; nevertheless, linear regression is not the most
+appropriate choice for this data:%
+\index{model}%
 \index{fitted values}
 
 \begin{itemize}
@@ -9665,17 +9765,17 @@ appropriate choice for this data:
 \item First, there is no reason to expect the long-term trend to be a
   line or any other simple function.  In general, prices are
   determined by supply and demand, both of which vary over time in
-  unpredictable ways.
+  unpredictable ways.%
 \index{trend}
 
 \item Second, the linear regression model gives equal weight to all
   data, recent and past.  For purposes of prediction, we should
-  probably give more weight to recent data.
+  probably give more weight to recent data.%
 \index{weight}
 
 \item Finally, one of the assumptions of linear regression is that the
   residuals are uncorrelated noise.  With time series data, this
-  assumption is often false because successive values are correlated.
+  assumption is often false because successive values are correlated.%
 \index{residuals}
 
 \end{itemize}
@@ -9687,20 +9787,20 @@ for time series data.
 \section{Moving averages}
 
 Most time series analysis is based on the modeling assumption that the
-observed series is the sum of three components:
-\index{model}
+observed series is the sum of three components:%
+\index{model}%
 \index{moving average}
 
 \begin{itemize}
 
-\item Trend: A smooth function that captures persistent changes.
+\item Trend: A smooth function that captures persistent changes.%
 \index{trend}
 
 \item Seasonality: Periodic variation, possibly including daily,
-weekly, monthly, or yearly cycles.
+weekly, monthly, or yearly cycles.%
 \index{seasonality}
 
-\item Noise: Random variation around the long-term trend.
+\item Noise: Random variation around the long-term trend.%
 \index{noise}
 
 \end{itemize}
@@ -9709,19 +9809,19 @@ Regression is one way to extract the trend from a series, as we
 saw in the previous section.  But if the trend is not a simple
 function, a good alternative is a {\bf moving average}.  A moving
 average divides the series into overlapping regions, called {\bf windows},
-and computes the average of the values in each window.
+and computes the average of the values in each window.%
 \index{window}
 
 One of the simplest moving averages is the {\bf rolling mean}, which
 computes the mean of the values in each window.  For example, if
 the window size is 3, the rolling mean computes the mean of
-values 0 through 2, 1 through 3, 2 through 4, etc.
-\index{rolling mean}
+values 0 through 2, 1 through 3, 2 through 4, etc.%
+\index{rolling mean}%
 \index{mean!rolling}
 
 pandas provides \verb"rolling_mean", which takes a Series and a
-window size and returns a new Series.
-\index{pandas}
+window size and returns a new Series.%
+\index{pandas}%
 \index{Series}
 
 \begin{verbatim}
@@ -9740,14 +9840,14 @@ Before we can apply \verb"rolling_mean" to the cannabis data, we
 have to deal with missing values.  There are a few days in the
 observed interval with no reported transactions for one or more
 quality categories, and a period in 2013 when data collection was
-not active.
+not active.%
 \index{missing values}
 
 In the DataFrames we have used so far, these dates are absent;
 the index skips days with no data.  For the analysis that follows,
 we need to represent this missing data explicitly.  We can do
-that by ``reindexing'' the DataFrame:
- \index{DataFrame}
+that by ``reindexing'' the DataFrame:%
+\index{DataFrame}%
 \index{reindex}
 
 \begin{verbatim}
@@ -9758,8 +9858,8 @@ that by ``reindexing'' the DataFrame:
 The first line computes a date range that includes every day from the
 beginning to the end of the observed interval.  The second line
 creates a new DataFrame with all of the data from {\tt daily}, but
-including rows for all dates, filled with {\tt nan}.
-\index{interval}
+including rows for all dates, filled with {\tt nan}.%
+\index{interval}%
 \index{date range}
 
 Now we can plot the rolling mean like this:
@@ -9770,15 +9870,15 @@ Now we can plot the rolling mean like this:
 \end{verbatim}
 
 The window size is 30, so each value in \verb"roll_mean" is
-the mean of 30 values from {\tt reindexed.ppg}.  
-\index{pandas}
+the mean of 30 values from {\tt reindexed.ppg}.%
+\index{pandas}%
 \index{window}
 
 \begin{figure}
 % timeseries.py
 \centerline{\includegraphics[height=2.5in]{figs/timeseries10.pdf}}
 \caption{Daily price and a rolling mean (left) and exponentially-weighted
-moving average (right).}
+moving average (right).}%
 \label{timeseries10}
 \end{figure}
 
@@ -9787,9 +9887,9 @@ shows the result.
 The rolling mean seems to do a good job of smoothing out the noise and
 extracting the trend.  The first 29 values are {\tt nan}, and wherever
 there's a missing value, it's followed by another 29 {\tt nan}s.
-There are ways to fill in these gaps, but they are a minor nuisance.
-\index{missing values}
-\index{noise}
+There are ways to fill in these gaps, but they are a minor nuisance.%
+\index{missing values}%
+\index{noise}%
 \index{smoothing}
 
 An alternative is the {\bf exponentially-weighted moving average} (EWMA),
@@ -9797,9 +9897,9 @@ which has two advantages.  First, as the name suggests, it computes
 a weighted average where the most recent value has the highest weight
 and the weights for previous values drop off exponentially.
 Second, the pandas implementation of EWMA handles missing values
-better.
-\index{reindex}
-\index{exponentially-weighted moving average}
+better.%
+\index{reindex}%
+\index{exponentially-weighted moving average}%
 \index{EWMA}
 
 \begin{verbatim}
@@ -9810,15 +9910,15 @@ better.
 The {\bf span} parameter corresponds roughly to the window size of
 a moving average; it controls how fast the weights drop off, so it
 determines the number of points that make a non-negligible contribution
-to each average.
-\index{span}
+to each average.%
+\index{span}%
 \index{window}
 
 Figure~\ref{timeseries10} (right) shows the EWMA for the same data.
 It is similar to the rolling mean, where they are both defined,
 but it has no missing values, which makes it easier to work with.  The
 values are noisy at the beginning of the time series, because they are
-based on fewer data points.
+based on fewer data points.%
 \index{missing values}
 
 
@@ -9829,13 +9929,13 @@ next step is to investigate seasonality, which is periodic behavior.
 Time series data based on human behavior often exhibits daily,
 weekly, monthly, or yearly cycles.  In the next section I present
 methods to test for seasonality, but they don't work well with
-missing data, so we have to solve that problem first.
-\index{missing values}
+missing data, so we have to solve that problem first.%
+\index{missing values}%
 \index{seasonality}
 
 A simple and common way to fill missing data is to use a moving
-average.  The Series method {\tt fillna} does just what we want:
-\index{Series}
+average.  The Series method {\tt fillna} does just what we want:%
+\index{Series}%
 \index{fillna}
 
 \begin{verbatim}
@@ -9849,8 +9949,8 @@ create a new one.
 
 A drawback of this method is that it understates the noise in the
 series.  We can solve that problem by adding in resampled
-residuals:
-\index{resampling}
+residuals:%
+\index{resampling}%
 \index{noise}
 
 \begin{verbatim}
@@ -9870,23 +9970,23 @@ residuals:
 when {\tt ppg} is {\tt nan}.  \verb"fake_data" contains the
 sum of the moving average and a random sample of residuals.
 Finally, {\tt fillna} replaces {\tt nan} with values from
-\verb"fake_data".
-\index{dropna}
-\index{fillna}
+\verb"fake_data".%
+\index{dropna}%
+\index{fillna}%
 \index{NaN}
 
 \begin{figure}
 % timeseries.py
 \centerline{\includegraphics[height=2.5in]{figs/timeseries8.pdf}}
-\caption{Daily price with filled data.}
+\caption{Daily price with filled data.}%
 \label{timeseries8}
 \end{figure}
 
 Figure~\ref{timeseries8} shows the result.  The filled data is visually
 similar to the actual values.  Since the resampled residuals are
 random, the results are different every time; later we'll see how
-to characterize the error created by missing values.
-\index{resampling}
+to characterize the error created by missing values.%
+\index{resampling}%
 \index{missing values}
 
 
@@ -9898,13 +9998,13 @@ you might expect it to be high for a few more days; and
 if it's low, you might expect it to stay low.  A pattern
 like this is called {\bf serial
 correlation}, because each value is correlated with the next one
-in the series.
-\index{correlation!serial}
+in the series.%
+\index{correlation!serial}%
 \index{serial correlation}
 
 To compute serial correlation, we can shift the time series
 by an interval called a {\bf lag}, and then compute the correlation
-of the shifted series with the original:
+of the shifted series with the original:%
 \index{lag}
 
 \begin{verbatim}
@@ -9916,7 +10016,7 @@ def SerialCorr(series, lag=1):
 \end{verbatim}
 
 After the shift, the first {\tt lag} values are {\tt nan}, so
-I use a slice to remove them before computing {\tt Corr}.
+I use a slice to remove them before computing {\tt Corr}.%
 \index{NaN}
 
 %high 0.480121816154
@@ -9932,7 +10032,7 @@ half of the series and values below the mean in the second half.
 
 It is more interesting to see if the correlation persists if you
 subtract away the trend.  For example, we can compute the residual
-of the EWMA and then compute its serial correlation:
+of the EWMA and then compute its serial correlation:%
 \index{EWMA}
 
 \begin{verbatim}
@@ -9944,11 +10044,11 @@ of the EWMA and then compute its serial correlation:
 With lag=1, the serial correlations for the de-trended data are
 -0.022 for high quality, -0.015 for medium, and 0.036 for low.
 These values are small, indicating that there is little or
-no one-day serial correlation in this series.
+no one-day serial correlation in this series.%
 \index{pandas}
 
 To check for weekly, monthly, and yearly seasonality, I ran
-the analysis again with different lags.  Here are the results:
+the analysis again with different lags.  Here are the results:%
 \index{seasonality}
 
 \begin{center}
@@ -9966,8 +10066,9 @@ lag & high & medium & low \\ \hline
 In the next section we'll test whether these correlations are
 statistically significant (they are not), but at this point we can
 tentatively conclude that there are no substantial seasonal patterns
-in these series, at least not with these lags.
-  \index{significant} \index{statistically significant}
+in these series, at least not with these lags.%
+\index{significant}%
+\index{statistically significant}
 
 
 \section{Autocorrelation}
@@ -9976,13 +10077,13 @@ If you think a series might have some serial correlation, but you
 don't know which lags to test, you can test them all!  The {\bf
   autocorrelation function} is a function that maps from lag to the
 serial correlation with the given lag.  ``Autocorrelation'' is another
-name for serial correlation, used more often when the lag is not 1.
+name for serial correlation, used more often when the lag is not 1.%
 \index{autocorrelation function}
 
 StatsModels, which we used for linear regression in
 Section~\ref{statsmodels}, also provides functions for time series
 analysis, including {\tt acf}, which computes the autocorrelation
-function:
+function:%
 \index{StatsModels}
 
 \begin{verbatim}
@@ -9996,7 +10097,7 @@ lags from 0 through {\tt nlags}.  The {\tt unbiased} flag tells
 is an array of correlations.  If we select daily prices for high
 quality, and extract correlations for lags 1, 7, 30, and 365, we can
 confirm that {\tt acf} and {\tt SerialCorr} yield approximately
-the same results:
+the same results:%
 \index{acf}
 
 \begin{verbatim}
@@ -10005,14 +10106,14 @@ the same results:
 \end{verbatim}
 
 With {\tt lag=0}, {\tt acf} computes the correlation of the series
-with itself, which is always 1.
+with itself, which is always 1.%
 \index{lag}
 
 \begin{figure}
 % timeseries.py
 \centerline{\includegraphics[height=2.5in]{figs/timeseries9.pdf}}
 \caption{Autocorrelation function for daily prices (left), and
-daily prices with a simulated weekly seasonality (right).}
+daily prices with a simulated weekly seasonality (right).}%
 \label{timeseries9}
 \end{figure}
 
@@ -10025,14 +10126,15 @@ the false positive rate is 5\%, and
 we are computing 120 correlations (40 lags for each of 3 times series),
 we expect to see about 6 points outside this region.  In fact, there
 are 7.  We conclude that there are no autocorrelations
-in these series that could not be explained by chance.
-\index{p-value}
-  \index{significant} \index{statistically significant}
+in these series that could not be explained by chance.%
+\index{p-value}%
+\index{significant}%
+\index{statistically significant}%
 \index{false positive}
 
 I computed the gray regions by resampling the residuals.  You
 can see my code in {\tt timeseries.py}; the function is called
-{\tt SimulateAutocorrelation}.
+{\tt SimulateAutocorrelation}.%
 \index{resampling}
 
 To see what the autocorrelation function looks like when there is a
@@ -10040,9 +10142,9 @@ seasonal component, I generated simulated data by adding a weekly
 cycle.  Assuming that demand for cannabis is higher on weekends, we
 might expect the price to be higher.  To simulate this effect, I
 select dates that fall on Friday or Saturday and add a random amount
-to the price, chosen from a uniform distribution from \$0 to \$2.
-\index{simulation}
-\index{uniform distribution}
+to the price, chosen from a uniform distribution from \$0 to \$2.%
+\index{simulation}%
+\index{uniform distribution}%
 \index{distribution!uniform}
 
 \begin{verbatim}
@@ -10058,9 +10160,9 @@ week is Friday or Saturday.  {\tt fake} is a new DataFrame, initially
 a copy of {\tt daily}, which we modify by adding random values
 to {\tt ppg}.  {\tt frisat.sum()} is the total number of Fridays
 and Saturdays, which is the number of random values we have to
-generate.
-\index{DataFrame}
-\index{Series}
+generate.%
+\index{DataFrame}%
+\index{Series}%
 \index{boolean}
 
 Figure~\ref{timeseries9} (right) shows autocorrelation functions for
@@ -10069,9 +10171,10 @@ correlations are highest when the lag is a multiple of 7.  For
 high and medium quality, the new correlations are statistically
 significant.  For low quality they are not, because residuals in this
 category are large; the effect would have to be bigger
-to be visible through the noise.
-  \index{significant} \index{statistically significant}
-\index{residuals}
+to be visible through the noise.%
+\index{significant}%
+\index{statistically significant}%
+\index{residuals}%
 \index{lag}
 
 
@@ -10079,14 +10182,14 @@ to be visible through the noise.
 
 Time series analysis can be used to investigate, and sometimes
 explain, the behavior of systems that vary in time.  It can also
-make predictions.
+make predictions.%
 \index{prediction}
 
 The linear regressions we used in Section~\ref{timeregress} can be
 used for prediction.  The RegressionResults class provides {\tt
   predict}, which takes a DataFrame containing the explanatory
-variables and returns a sequence of predictions.  Here's the code:
-\index{explanatory variable}
+variables and returns a sequence of predictions.  Here's the code:%
+\index{explanatory variable}%
 \index{linear regression}
 
 \begin{verbatim}
@@ -10102,8 +10205,8 @@ def GenerateSimplePrediction(results, years):
 {\tt results} is a RegressionResults object; {\tt years} is the
 sequence of time values we want predictions for.  The function
 constructs a DataFrame, passes it to {\tt predict}, and
-returns the result.
-\index{pandas}
+returns the result.%
+\index{pandas}%
 \index{DataFrame}
 
 If all we want is a single, best-guess prediction, we're done.  But
@@ -10117,18 +10220,18 @@ There are three sources of error we should take into account:
 \item Sampling error: The prediction is based on estimated
 parameters, which depend on random variation
 in the sample.  If we run the experiment again, we expect
-the estimates to vary.
-\index{sampling error}
+the estimates to vary.%
+\index{sampling error}%
 \index{parameter}
 
 \item Random variation:  Even if the estimated parameters are
 perfect, the observed data varies randomly around the long-term
-trend, and we expect this variation to continue in the future.
+trend, and we expect this variation to continue in the future.%
 \index{noise}
 
 \item Modeling error: We have already seen evidence that the long-term
 trend is not linear, so predictions based on a linear model will
-eventually fail.  
+eventually fail.%
 \index{modeling error}
 
 \end{itemize}
@@ -10149,7 +10252,7 @@ Section~\ref{regest}.  As always, the goal is to use the actual
 observations to simulate what would happen if we ran the experiment
 again.  The simulations are based on the assumption that the estimated
 parameters are correct, but the random residuals could have been
-different.  Here is a function that runs the simulations:
+different.  Here is a function that runs the simulations:%
 \index{resampling}
 
 \begin{verbatim}
@@ -10167,8 +10270,8 @@ def SimulateResults(daily, iters=101):
 \end{verbatim}
 
 {\tt daily} is a DataFrame containing the observed prices;
-{\tt iters} is the number of simulations to run.
-\index{DataFrame}
+{\tt iters} is the number of simulations to run.%
+\index{DataFrame}%
 \index{price}
 
 {\tt SimulateResults} uses {\tt RunLinearModel}, from
@@ -10178,8 +10281,8 @@ of the observed values.
 Each time through the loop, it generates a ``fake'' dataset by
 resampling the residuals and adding them to the fitted values.  Then
 it runs a linear model on the fake data and stores the RegressionResults
-object.
-\index{model}
+object.%
+\index{model}%
 \index{residuals}
 
 The next step is to use the simulated results to generate predictions:
@@ -10206,19 +10309,19 @@ floats that specifies the interval to generate predictions for,
 and \verb"add_resid", which indicates whether it should add resampled
 residuals to the straight-line prediction.
 {\tt GeneratePredictions} iterates through the sequence of
-RegressionResults and generates a sequence of predictions.
+RegressionResults and generates a sequence of predictions.%
 \index{resampling}
 
 \begin{figure}
 % timeseries.py
 \centerline{\includegraphics[height=2.5in]{figs/timeseries4.pdf}}
 \caption{Predictions based on linear fits, showing variation due
-to sampling error and prediction error.}
+to sampling error and prediction error.}%
 \label{timeseries4}
 \end{figure}
 
 Finally, here's the code that plots a 90\% confidence interval for
-the predictions:
+the predictions:%
 \index{confidence interval}
 
 \begin{verbatim}
@@ -10239,67 +10342,67 @@ def PlotPredictions(daily, years, iters=101, percent=90):
 {\tt PlotPredictions} calls {\tt GeneratePredictions} twice: once
 with \verb"add_resid=True" and again with \verb"add_resid=False".
 It uses {\tt PercentileRows} to select the 5th and 95th percentiles
-for each year, then plots a gray region between these bounds.
+for each year, then plots a gray region between these bounds.%
 \index{FillBetween}
 
 Figure~\ref{timeseries4} shows the result.
 The dark gray region represents a 90\% confidence interval for
 the sampling error; that is, uncertainty about the estimated
-slope and intercept due to sampling.
+slope and intercept due to sampling.%
 \index{sampling error}
 
 The lighter region shows
 a 90\% confidence interval for prediction error, which is the
-sum of sampling error and random variation.
+sum of sampling error and random variation.%
 \index{noise}
 
 These regions quantify sampling error and random variation, but
 not modeling error.  In general modeling error is hard to quantify,
 but in this case we can address at least one source of error,
-unpredictable external events.
+unpredictable external events.%
 \index{modeling error}
 
 The regression model is based on the assumption that the system
 is {\bf stationary}; that is, that the parameters of the model
 don't change over time.
 Specifically, it assumes that the slope and
-intercept are constant, as well as the distribution of residuals.
-\index{stationary model}
+intercept are constant, as well as the distribution of residuals.%
+\index{stationary model}%
 \index{parameter}
 
 But looking at the moving averages in Figure~\ref{timeseries10}, it
 seems like the slope changes at least once during the observed
 interval, and the variance of the residuals seems bigger in the first
-half than the second.
+half than the second.%
 \index{slope}
 
 As a result, the parameters we get depend on the interval we
 observe.  To see how much effect this has on the predictions,
 we can extend {\tt SimulateResults} to use intervals of observation
 with different start and end dates.  My implementation is in
-{\tt timeseries.py}.
+{\tt timeseries.py}.%
 \index{simulation}
 
 \begin{figure}
 % timeseries.py
 \centerline{\includegraphics[height=2.5in]{figs/timeseries5.pdf}}
 \caption{Predictions based on linear fits, showing
-variation due to the interval of observation.}
+variation due to the interval of observation.}%
 \label{timeseries5}
 \end{figure}
 
 Figure~\ref{timeseries5} shows the result for the medium quality
 category.  The lightest gray area shows a confidence interval that
 includes uncertainty due to sampling error, random variation, and
-variation in the interval of observation.
-\index{confidence interval}
+variation in the interval of observation.%
+\index{confidence interval}%
 \index{interval}
 
 The model based on the entire interval has positive slope, indicating
 that prices were increasing.  But the most recent interval shows signs
 of decreasing prices, so models based on the most recent data have
 negative slope.  As a result, the widest predictive interval includes
-the possibility of decreasing prices over the next year.
+the possibility of decreasing prices over the next year.%
 \index{model}
 
 
@@ -10308,7 +10411,7 @@ the possibility of decreasing prices over the next year.
 Time series analysis is a big topic; this chapter has only scratched
 the surface.  An important tool for working with time series data
 is autoregression, which I did not cover here, mostly because it turns
-out not to be useful for the example data I worked with.
+out not to be useful for the example data I worked with.%
 \index{time series}
 
 But once you
@@ -10316,7 +10419,7 @@ have learned the material in this chapter, you are well prepared
 to learn about autoregression.  One resource I recommend is
 Philipp Janert's book, {\it Data Analysis with Open Source Tools},
 O'Reilly Media, 2011.  His chapter on time series analysis picks up
-where this one leaves off.
+where this one leaves off.%
 \index{Janert, Philipp}
 
 
@@ -10329,16 +10432,16 @@ The linear model I used in this chapter has the obvious drawback
 that it is linear, and there is no reason to expect prices to
 change linearly over time.
 We can add flexibility to the model by adding a quadratic term,
-as we did in Section~\ref{nonlinear}.  
-\index{nonlinear}
-\index{linear model}
+as we did in Section~\ref{nonlinear}.%
+\index{nonlinear}%
+\index{linear model}%
 \index{quadratic model}
 
 Use a quadratic model to fit the time series of daily prices,
 and use the model to generate predictions.  You will have to
 write a version of {\tt RunLinearModel} that runs that quadratic
 model, but after that you should be able to reuse code in
-{\tt timeseries.py} to generate predictions.
+{\tt timeseries.py} to generate predictions.%
 \index{prediction}
 
 \end{exercise}
@@ -10348,23 +10451,24 @@ Write a definition for a class named {\tt SerialCorrelationTest}
 that extends {\tt HypothesisTest} from Section~\ref{hypotest}.
 It should take a series and a lag as data, compute the serial
 correlation of the series with the given lag, and then compute
-the p-value of the observed correlation.
-\index{HypothesisTest}
-\index{p-value}
+the p-value of the observed correlation.%
+\index{HypothesisTest}%
+\index{p-value}%
 \index{lag}
 
 Use this class to test whether the serial correlation in raw
 price data is statistically significant.  Also test the residuals
 of the linear model and (if you did the previous exercise),
-the quadratic model.
-\index{quadratic model}
-  \index{significant} \index{statistically significant}
+the quadratic model.%
+\index{quadratic model}%
+\index{significant}%
+\index{statistically significant}
 
 \end{exercise}
 
 \begin{exercise}
 There are several ways to extend the EWMA model to generate predictions.
-One of the simplest is something like this:
+One of the simplest is something like this:%
 \index{EWMA}
 
 \begin{enumerate}
@@ -10373,12 +10477,12 @@ One of the simplest is something like this:
 as an intercept, {\tt inter}.
 
 \item Compute the EWMA of differences between successive elements in
-the time series and use the last point as a slope, {\tt slope}.
+the time series and use the last point as a slope, {\tt slope}.%
 \index{slope}
 
 \item To predict values at future times, compute {\tt inter + slope * dt},
 where {\tt dt} is the difference between the time of the prediction and
-the time of the last observation.
+the time of the last observation.%
 \index{prediction}
 
 \end{enumerate}
@@ -10390,17 +10494,17 @@ observation.  A few hints:
 
 \item Use {\tt timeseries.FillMissing} to fill in missing values
 before running this analysis.  That way the time between consecutive
-elements is consistent.
+elements is consistent.%
 \index{missing values}
 
 \item Use {\tt Series.diff} to compute differences between successive
-elements.
+elements.%
 \index{Series}
 
-\item Use {\tt reindex} to extend the DataFrame index into the future.
+\item Use {\tt reindex} to extend the DataFrame index into the future.%
 \index{reindex}
 
-\item Use {\tt fillna} to put your predicted values into the DataFrame.
+\item Use {\tt fillna} to put your predicted values into the DataFrame.%
 \index{fillna}
 
 \end{itemize}
@@ -10414,49 +10518,51 @@ elements.
 
 \item time series: A dataset where each value is associated with
 a timestamp, often a series of measurements and the times they
-were collected.
+were collected.%
 \index{time series}
 
 \item window: A sequence of consecutive values in a time series,
-often used to compute a moving average.
+often used to compute a moving average.%
 \index{window}
 
 \item moving average: One of several statistics intended to estimate
 the underlying trend in a time series by computing averages (of
-some kind) for a series of overlapping windows.
+some kind) for a series of overlapping windows.%
 \index{moving average}
 
 \item rolling mean: A moving average based on the mean value in
-each window.
+each window.%
 \index{rolling mean}
 
 \item exponentially-weighted moving average (EWMA): A moving
 average based on a weighted mean that gives the highest weight
 to the most recent values, and exponentially decreasing weights
-to earlier values. \index{exponentially-weighted moving average} \index{EWMA}
+to earlier values.%
+\index{exponentially-weighted moving average}%
+\index{EWMA}
 
 \item span: A parameter of EWMA that determines how quickly the
-weights decrease.
+weights decrease.%
 \index{span}
 
 \item serial correlation: Correlation between a time series and
-a shifted or lagged version of itself.
+a shifted or lagged version of itself.%
 \index{serial correlation}
 
 \item lag: The size of the shift in a serial correlation or
-autocorrelation.
+autocorrelation.%
 \index{lag}
 
 \item autocorrelation: A more general term for a serial correlation
-with any amount of lag.
+with any amount of lag.%
 \index{autocorrelation function}
 
 \item autocorrelation function: A function that maps from lag to
 serial correlation.
 
 \item stationary: A model is stationary if the parameters and the
-distribution of residuals does not change over time.
-\index{model}
+distribution of residuals does not change over time.%
+\index{model}%
 \index{stationary model}
 
 \end{itemize}
@@ -10468,38 +10574,41 @@ distribution of residuals does not change over time.
 {\bf Survival analysis} is a way to describe how long things last.
 It is often used to study human lifetimes, but it
 also applies to ``survival'' of mechanical and electronic components, or
-more generally to intervals in time before an event.
-\index{survival analysis}
-\index{mechanical component}
+more generally to intervals in time before an event.%
+\index{survival analysis}%
+\index{mechanical component}%
 \index{electrical component}
 
 If someone you know has been diagnosed with a life-threatening
 disease, you might have seen a ``5-year survival rate,'' which
 is the probability of surviving five years after diagnosis.  That
-estimate and related statistics are the result of survival analysis.
+estimate and related statistics are the result of survival analysis.%
 \index{survival rate}
 
 The code in this chapter is in {\tt survival.py}.  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
-\section{Survival curves}
+\section{Survival curves}%
 \label{survival}
 
 The fundamental concept in survival analysis is the {\bf survival
   curve}, $S(t)$, which is a function that maps from a duration, $t$, to the
 probability of surviving longer than $t$.  If you know the distribution
 of durations, or ``lifetimes'', finding the survival curve is easy;
-it's just the complement of the CDF: \index{survival curve}
+it's just the complement of the CDF:%
+\index{survival curve}
 %
 \[ S(t) = 1 - \CDF(t) \]
 %
 where $CDF(t)$ is the probability of a lifetime less than or equal
-to $t$.
-\index{complementary CDF} \index{CDF!complementary} \index{CCDF}
+to $t$.%
+\index{complementary CDF}%
+\index{CDF!complementary}%
+\index{CCDF}
 
 For example, in the NSFG dataset, we know the duration of 11189
-complete pregnancies.  We can read this data and compute the CDF:
+complete pregnancies.  We can read this data and compute the CDF:%
 \index{pregnancy length}
 
 \begin{verbatim}
@@ -10514,25 +10623,25 @@ ectopic pregnancies, and pregnancies that were in progress when
 the respondent was interviewed.
 
 The DataFrame method {\tt query} takes a boolean expression and
-evaluates it for each row, selecting the rows that yield True.
-\index{DataFrame}
-\index{boolean}
+evaluates it for each row, selecting the rows that yield True.%
+\index{DataFrame}%
+\index{boolean}%
 \index{query}
 
 \begin{figure}
 % survival.py
 \centerline{\includegraphics[height=3.0in]{figs/survival1.pdf}}
 \caption{Cdf and survival curve for pregnancy length (top),
-hazard curve (bottom).}
+hazard curve (bottom).}%
 \label{survival1}
 \end{figure}
 
 Figure~\ref{survival1} (top) shows the CDF of pregnancy length
 and its complement, the survival curve.  To represent the
-survival curve, I define an object that wraps a Cdf and 
-adapts the interface:
-\index{Cdf}
-\index{pregnancy length}
+survival curve, I define an object that wraps a Cdf and
+adapts the interface:%
+\index{Cdf}%
+\index{pregnancy length}%
 \index{SurvivalFunction}
 
 \begin{verbatim}
@@ -10556,7 +10665,7 @@ curve.  In Python, a ``property'' is a method that can be
 invoked as if it were a variable.
 
 We can instantiate a {\tt SurvivalFunction} by passing
-the CDF of lifetimes:
+the CDF of lifetimes:%
 \index{property}
 
 \begin{verbatim}
@@ -10577,7 +10686,7 @@ the CDF of lifetimes:
 \end{verbatim}
 
 For example, {\tt sf[13]} is the fraction of pregnancies that
-proceed past the first trimester:
+proceed past the first trimester:%
 \index{trimester}
 
 \begin{verbatim}
@@ -10591,7 +10700,7 @@ About 86\% of pregnancies proceed past the first trimester;
 about 14\% do not.
 
 {\tt SurvivalFunction} provides {\tt Render}, so we can
-plot {\tt sf} using the functions in {\tt thinkplot}:
+plot {\tt sf} using the functions in {\tt thinkplot}:%
 \index{thinkplot}
 
 \begin{verbatim}
@@ -10601,11 +10710,11 @@ plot {\tt sf} using the functions in {\tt thinkplot}:
 Figure~\ref{survival1} (top) shows the result.  The curve is nearly
 flat between 13 and 26 weeks, which shows that few pregnancies
 end in the second trimester.  And the curve is steepest around 39
-weeks, which is the most common pregnancy length.
+weeks, which is the most common pregnancy length.%
 \index{pregnancy length}
 
 
-\section{Hazard function}
+\section{Hazard function}%
 \label{hazard}
 
 From the survival curve we can derive the {\bf hazard function};
@@ -10616,7 +10725,7 @@ $t$.  To be more precise:
 \[ \lambda(t) = \frac{S(t) - S(t+1)}{S(t)} \]
 %
 The numerator is the fraction of lifetimes that end at $t$, which
-is also $\PMF(t)$.
+is also $\PMF(t)$.%
 \index{hazard function}
 
 {\tt SurvivalFunction} provides {\tt MakeHazard}, which calculates
@@ -10636,9 +10745,9 @@ the hazard function:
 \end{verbatim}
 
 The {\tt HazardFunction} object is a wrapper for a pandas
-Series:
-\index{pandas}
-\index{Series}
+Series:%
+\index{pandas}%
+\index{Series}%
 \index{wrapper}
 
 \begin{verbatim}
@@ -10651,7 +10760,7 @@ class HazardFunction(object):
 
 {\tt d} can be a dictionary or any other type that can initialize
 a Series, including another Series.  {\tt label} is a string used
-to identify the HazardFunction when plotted.
+to identify the HazardFunction when plotted.%
 \index{HazardFunction}
 
 {\tt HazardFunction} provides \verb"__getitem__", so we can evaluate
@@ -10671,7 +10780,7 @@ pregnancy lengths.  For times after week 42, the hazard function
 is erratic because it is based on a small number of cases.
 Other than that the shape of the curve is as expected: it is
 highest around 39 weeks, and a little higher in the first
-trimester than in the second.
+trimester than in the second.%
 \index{pregnancy length}
 
 The hazard function is useful in its own right, but it is also an
@@ -10684,8 +10793,8 @@ next section.
 If someone gives you the CDF of lifetimes, it is easy to compute the
 survival and hazard functions.  But in many real-world
 scenarios, we can't measure the distribution of lifetimes directly.
-We have to infer it.
-\index{survival curve}
+We have to infer it.%
+\index{survival curve}%
 \index{CDF}
 
 For example, suppose you are following a group of patients to see how
@@ -10693,26 +10802,26 @@ long they survive after diagnosis.  Not all patients are diagnosed on
 the same day, so at any point in time, some patients have survived
 longer than others.  If some patients have died, we know their
 survival times.  For patients who are still alive, we don't know
-survival times, but we have a lower bound.
+survival times, but we have a lower bound.%
 \index{diagnosis}
 
 If we wait until all patients are dead, we can compute the survival
 curve, but if we are evaluating the effectiveness of a new treatment,
 we can't wait that long!  We need a way to estimate survival curves
-using incomplete information.
+using incomplete information.%
 \index{incomplete information}
 
 As a more cheerful example, I will use NSFG data to quantify how
 long respondents ``survive'' until they get married for the
 first time.  The range of respondents' ages is 14 to 44 years, so
 the dataset provides a snapshot of women at different stages in their
-lives.
+lives.%
 \index{marital status}
 
 For women who have been married, the dataset includes the date
 of their first marriage and their age at the time.
 For women who have not been married, we know their age when interviewed,
-but have no way of knowing when or if they will get married.
+but have no way of knowing when or if they will get married.%
 \index{age}
 
 Since we know the age at first marriage for {\em some\/} women, it
@@ -10729,7 +10838,7 @@ which is obviously incorrect.
 
 In this example it is not only desirable but necessary to include
 observations of unmarried women, which brings us to one of the central
-algorithms in survival analysis, {\bf Kaplan-Meier estimation}.
+algorithms in survival analysis, {\bf Kaplan-Meier estimation}.%
 \index{Kaplan-Meier estimation}
 
 The general idea is that we can use the data to estimate the hazard
@@ -10737,8 +10846,8 @@ function, then convert the hazard function to a survival curve.
 To estimate the hazard function, we consider, for each age,
 (1) the number of women who got married at that age and (2) the number
 of women ``at risk'' of getting married, which includes all women
-who were not married at an earlier age.
-\index{hazard function}
+who were not married at an earlier age.%
+\index{hazard function}%
 \index{at risk}
 
 Here's the code:
@@ -10773,9 +10882,8 @@ when they were interviewed.
 First, we precompute \verb"hist_complete", which is a Counter
 that maps from each age to the number of women married at that
 age, and \verb"hist_ongoing" which maps from each age to the
-number of unmarried women interviewed at that age.
-
-\index{Counter}
+number of unmarried women interviewed at that age.%
+\index{Counter}%
 \index{survival curve}
 
 {\tt ts} is the union of ages when respondents got married
@@ -10804,21 +10912,20 @@ At the end of the loop, we subtract from \verb"at_risk" the
 number of cases that ended or were censored at {\tt t}.
 
 Finally, we pass {\tt lams} to the {\tt HazardFunction}
-constructor and return the result.
-
+constructor and return the result.%
 \index{HazardFunction}
 
 
 \section{The marriage curve}
 
 To test this function, we have to do some data cleaning and
-transformation.  The NSFG variables we need are:
+transformation.  The NSFG variables we need are:%
 \index{marital status}
 
 \begin{itemize}
 
 \item {\tt cmbirth}: The respondent's date of birth, known for
-all respondents.
+all respondents.%
 \index{date of birth}
 
 \item {\tt cmintvw}: The date the respondent was interviewed,
@@ -10834,7 +10941,7 @@ married prior to the date of interview, 0 otherwise.
 
 The first three variables are encoded in ``century-months''; that is, the
 integer number of months since December 1899.  So century-month
-1 is January 1900.
+1 is January 1900.%
 \index{century month}
 
 First, we read the respondent file and replace invalid values of
@@ -10846,7 +10953,7 @@ First, we read the respondent file and replace invalid values of
 \end{verbatim}
 
 Then we compute each respondent's age when married and age when
-interviewed:
+interviewed:%
 \index{NaN}
 
 \begin{verbatim}
@@ -10856,7 +10963,7 @@ interviewed:
 
 Next we extract {\tt complete}, which is the age at marriage for
 women who have been married, and {\tt ongoing}, which is the
-age at interview for women who have not:
+age at interview for women who have not:%
 \index{age}
 
 \begin{verbatim}
@@ -10865,7 +10972,7 @@ age at interview for women who have not:
 \end{verbatim}
 
 Finally we compute the
-hazard function.
+hazard function.%
 \index{hazard function}
 
 \begin{verbatim}
@@ -10878,7 +10985,7 @@ higher in the 20s, and declining in the 30s.  It increases again in
 the 40s, but that is an artifact of the estimation process; as the
 number of respondents ``at risk'' decreases, a small number of
 women getting married yields a large estimated hazard.  The survival
-curve will smooth out this noise.
+curve will smooth out this noise.%
 \index{noise}
 
 
@@ -10892,8 +10999,8 @@ the complementary hazard function:
 \[ [1-\lambda(0)] [1-\lambda(1)] ... [1-\lambda(t)] \]
 %
 The {\tt HazardFunction} class provides {\tt MakeSurvival}, which
-computes this product:
-\index{cumulative product}
+computes this product:%
+\index{cumulative product}%
 \index{SurvivalFunction}
 
 \begin{verbatim}
@@ -10913,8 +11020,8 @@ hazard function, so it is the survival curve.
 
 Because of the way {\tt SurvivalFunction} is implemented, we have
 to compute the complement of {\tt ss}, make a Cdf, and then instantiate
-a SurvivalFunction object.
-\index{Cdf}
+a SurvivalFunction object.%
+\index{Cdf}%
 \index{complementary CDF}
 
 
@@ -10922,7 +11029,7 @@ a SurvivalFunction object.
 % survival.py
 \centerline{\includegraphics[height=2.5in]{figs/survival2.pdf}}
 \caption{Hazard function for age at first marriage (top) and
-survival curve (bottom).}
+survival curve (bottom).}%
 \label{survival2}
 \end{figure}
 
@@ -10939,14 +11046,14 @@ statistics were widely reported and became part of popular culture,
 but they were wrong then (because they were based on faulty analysis)
 and turned out to be even more wrong (because of cultural changes that
 were already in progress and continued).  In 2006, {\it Newsweek\/} ran
-an another article admitting that they were wrong.
+an another article admitting that they were wrong.%
 \index{Newsweek}
 
 I encourage you to read more about this article, the statistics it was
 based on, and the reaction.  It should remind you of the ethical
 obligation to perform statistical analysis with care, interpret the
 results with appropriate skepticism, and present them to the public
-accurately and honestly.
+accurately and honestly.%
 \index{ethics}
 
 
@@ -10955,17 +11062,17 @@ accurately and honestly.
 Kaplan-Meier analysis yields a single estimate of the survival curve,
 but it is also important to quantify the uncertainty of the estimate.
 As usual, there are three possible sources of error: measurement
-error, sampling error, and modeling error.
-\index{confidence interval}
-\index{modeling error}
+error, sampling error, and modeling error.%
+\index{confidence interval}%
+\index{modeling error}%
 \index{sampling error}
 
 In this example, measurement error is probably small.  People
 generally know when they were born, whether they've been married, and
-when.  And they can be expected to report this information accurately.
+when.  And they can be expected to report this information accurately.%
 \index{measurement error}
 
-We can quantify sampling error by resampling.  Here's the code:
+We can quantify sampling error by resampling.  Here's the code:%
 \index{resampling}
 
 \begin{verbatim}
@@ -10986,7 +11093,7 @@ def ResampleSurvival(resp, iters=101):
 {\tt ResampleSurvival} takes {\tt resp}, a DataFrame of respondents,
 and {\tt iters}, the number of times to resample.  It computes {\tt
   ts}, which is the sequence of ages where we will evaluate the survival
-curves.
+curves.%
 \index{DataFrame}
 
 Inside the loop, {\tt ResampleSurvival}:
@@ -10994,7 +11101,7 @@ Inside the loop, {\tt ResampleSurvival}:
 \begin{itemize}
 
 \item Resamples the respondents using {\tt ResampleRowsWeighted},
-which we saw in Section~\ref{weighted}.
+which we saw in Section~\ref{weighted}.%
 \index{weighted resampling}
 
 \item Calls {\tt EstimateSurvival}, which uses the process in the
@@ -11007,14 +11114,14 @@ previous sections to estimate the hazard and survival curves, and
 \verb"ss_seq" is a sequence of evaluated survival curves.
 {\tt PercentileRows} takes this sequence and computes the 5th and 95th
 percentiles, returning a 90\% confidence interval for the survival
-curve.
+curve.%
 \index{FillBetween}
 
 \begin{figure}
 % survival.py
 \centerline{\includegraphics[height=2.5in]{figs/survival3.pdf}}
 \caption{Survival curve for age at first marriage (dark line) and a 90\%
-confidence interval based on weighted resampling (gray line).}
+confidence interval based on weighted resampling (gray line).}%
 \label{survival3}
 \end{figure}
 
@@ -11023,8 +11130,8 @@ curve we estimated in the previous section.  The confidence
 interval takes into account the sampling weights, unlike the estimated
 curve.  The discrepancy between them indicates that the sampling
 weights have a substantial effect on the estimate---we will have
-to keep that in mind.
-\index{confidence interval}
+to keep that in mind.%
+\index{confidence interval}%
 \index{sampling weight}
 
 
@@ -11043,8 +11150,8 @@ patterns are different for women born in different generations.
 We can investigate this effect by grouping respondents according
 to their decade of birth.  Groups like this, defined by date of
 birth or similar events, are called {\bf cohorts}, and differences
-between the groups are called {\bf cohort effects}.
-\index{cohort}
+between the groups are called {\bf cohort effects}.%
+\index{cohort}%
 \index{cohort effect}
 
 To investigate cohort effects in the NSFG marriage data, I gathered
@@ -11061,8 +11168,8 @@ and the Cycle 5 data from 1995.  In total these datasets include
 \end{verbatim}
 
 For each DataFrame, {\tt resp}, I use {\tt cmbirth} to compute the
-decade of birth for each respondent:
-\index{pandas}
+decade of birth for each respondent:%
+\index{pandas}%
 \index{DataFrame}
 
 \begin{verbatim}
@@ -11078,15 +11185,15 @@ object.  For each birth date, we instantiate a {\tt DateOffset} that
 contains the century-month and add it to {\tt month0}; the result
 is a sequence of Timestamps, which is converted to a {\tt
   DateTimeIndex}.  Finally, we extract {\tt year} and compute
-decades.
-\index{DateTimeIndex}
-\index{Index}
+decades.%
+\index{DateTimeIndex}%
+\index{Index}%
 \index{century month}
 
 To take into account the sampling weights, and also to show
 variability due to sampling error, I resample the data,
-group respondents by decade, and plot survival curves:
-\index{resampling}
+group respondents by decade, and plot survival curves:%
+\index{resampling}%
 \index{sampling error}
 
 \begin{verbatim}
@@ -11103,9 +11210,9 @@ Data from the three NSFG cycles use different sampling weights,
 so I resample them separately and then use {\tt concat}
 to merge them into a single DataFrame.  The parameter \verb"ignore_index"
 tells {\tt concat} not to match up respondents by index; instead
-it creates a new index from 0 to 30768.
-\index{pandas}
-\index{DataFrame}
+it creates a new index from 0 to 30768.%
+\index{pandas}%
+\index{DataFrame}%
 \index{groupby}
 
 {\tt EstimateSurvivalByDecade} plots survival curves for each cohort:
@@ -11120,7 +11227,7 @@ def EstimateSurvivalByDecade(resp):
 \begin{figure}
 % survival.py
 \centerline{\includegraphics[height=2.5in]{figs/survival4.pdf}}
-\caption{Survival curves for respondents born during different decades.}
+\caption{Survival curves for respondents born during different decades.}%
 \label{survival4}
 \end{figure}
 
@@ -11136,7 +11243,7 @@ visible:
 to age 25, they were marrying at slower rates than their predecessors.
 After age 25, they were marrying faster.  By age 32 they had overtaken
 the 50s cohort, and at age 44 they are substantially more likely to
-have married.
+have married.%
 \index{marital status}
 
 Women born in the 60s turned 25 between 1985 and 1995.  Remembering
@@ -11144,7 +11251,7 @@ that the {\it Newsweek\/} article I mentioned was published in 1986, it
 is tempting to imagine that the article triggered a marriage boom.
 That explanation would be too pat, but it is possible that the article
 and the reaction to it were indicative of a mood that affected the
-behavior of this cohort.
+behavior of this cohort.%
 \index{Newsweek}
 
 \item The pattern of the 70s cohort is similar.  They are less
@@ -11157,7 +11264,7 @@ have to wait for the next cycle of the NSFG.
 
 \end{itemize}
 
-In the meantime we can make some predictions.
+In the meantime we can make some predictions.%
 \index{prediction}
 
 
@@ -11165,12 +11272,12 @@ In the meantime we can make some predictions.
 
 The survival curve for the 70s cohort ends at about age 38;
 for the 80s cohort it ends at age 28, and for the 90s cohort
-we hardly have any data at all.
+we hardly have any data at all.%
 \index{extrapolation}
 
 We can extrapolate these curves by ``borrowing'' data from the
 previous cohort.  HazardFunction provides a method, {\tt Extend}, that
-copies the tail from another longer HazardFunction:
+copies the tail from another longer HazardFunction:%
 \index{HazardFunction}
 
 \begin{verbatim}
@@ -11186,8 +11293,8 @@ As we saw in Section~\ref{hazard}, the HazardFunction contains a Series
 that maps from $t$ to $\lambda(t)$.  {\tt Extend} finds {\tt last},
 which is the last index in {\tt self.series}, selects values from
 {\tt other} that come later than {\tt last}, and appends them
-onto {\tt self.series}.
-\index{pandas}
+onto {\tt self.series}.%
+\index{pandas}%
 \index{Series}
 
 Now we can extend the HazardFunction for each cohort, using values
@@ -11209,7 +11316,7 @@ def PlotPredictionsByDecade(groups):
 \end{verbatim}
 
 {\tt groups} is a GroupBy object with respondents grouped by decade of
-birth.  The first loop computes the HazardFunction for each group.
+birth.  The first loop computes the HazardFunction for each group.%
 \index{groupby}
 
 The second loop extends each HazardFunction with values from
@@ -11221,14 +11328,14 @@ a SurvivalFunction and plots it.
 % survival.py
 \centerline{\includegraphics[height=2.5in]{figs/survival5.pdf}}
 \caption{Survival curves for respondents born during different decades,
-with predictions for the later cohorts.}
+with predictions for the later cohorts.}%
 \label{survival5}
 \end{figure}
 
 Figure~\ref{survival5} shows the results; I've removed the 50s cohort
 to make the predictions more visible.  These results suggest that by
 age 40, the most recent cohorts will converge with the 60s cohort,
-with fewer than 20\% never married.
+with fewer than 20\% never married.%
 \index{visualization}
 
 
@@ -11237,7 +11344,7 @@ with fewer than 20\% never married.
 Given a survival curve, we can compute the expected remaining
 lifetime as a function of current age.  For example, given the
 survival curve of pregnancy length from Section~\ref{survival},
-we can compute the expected time until delivery.
+we can compute the expected time until delivery.%
 \index{pregnancy length}
 
 The first step is to extract the PMF of lifetimes.  {\tt SurvivalFunction}
@@ -11260,8 +11367,8 @@ provides a method that does that:
 
 Remember that the SurvivalFunction contains the Cdf of lifetimes.
 The loop copies the values and probabilities from the Cdf into
-a Pmf.
-\index{Pmf}
+a Pmf.%
+\index{Pmf}%
 \index{Cdf}
 
 {\tt cutoff} is the highest probability in the Cdf, which is 1
@@ -11270,12 +11377,12 @@ If the Cdf is incomplete, we plug in the provided value, {\tt filler},
 to cap it off.
 
 The Cdf of pregnancy lengths is complete, so we don't have to worry
-about this detail yet.
+about this detail yet.%
 \index{pregnancy length}
 
 The next step is to compute the expected remaining lifetime, where
 ``expected'' means average.  {\tt SurvivalFunction}
-provides a method that does that, too:
+provides a method that does that, too:%
 \index{expected remaining lifetime}
 
 \begin{verbatim}
@@ -11298,7 +11405,7 @@ summarize the distribution of remaining lifetimes.
 
 {\tt pmf} is the Pmf of lifetimes extracted from the SurvivalFunction.
 {\tt d} is a dictionary that contains the results, a map from
-current age, {\tt t}, to expected remaining lifetime.
+current age, {\tt t}, to expected remaining lifetime.%
 \index{Pmf}
 
 The loop iterates through the values in the Pmf.  For each value
@@ -11310,14 +11417,14 @@ values.
 Then it uses {\tt func} to summarize the conditional distribution.
 In this example the result is the mean pregnancy length, given that
 the length exceeds {\tt t}.  By subtracting {\tt t} we get the
-mean remaining pregnancy length.
+mean remaining pregnancy length.%
 \index{pregnancy length}
 
 \begin{figure}
 % survival.py
 \centerline{\includegraphics[height=2.5in]{figs/survival6.pdf}}
 \caption{Expected remaining pregnancy length (left) and
-years until first marriage (right).}
+years until first marriage (right).}%
 \label{survival6}
 \end{figure}
 
@@ -11325,7 +11432,7 @@ Figure~\ref{survival6} (left) shows the expected remaining pregnancy
 length as a function of the current duration.  For example, during
 Week 0, the expected remaining duration is about 34 weeks.  That's
 less than full term (39 weeks) because terminations of pregnancy
-in the first trimester bring the average down.
+in the first trimester bring the average down.%
 \index{pregnancy length}
 
 The curve drops slowly during the first trimester.  After 13 weeks,
@@ -11338,7 +11445,7 @@ same; with each week that passes, the destination gets no closer.
 Processes with this property are called {\bf memoryless} because
 the past has no effect on the predictions.
 This behavior is the mathematical basis of the infuriating mantra
-of obstetrics nurses: ``any day now.''
+of obstetrics nurses: ``any day now.''%
 \index{memoryless}
 
 Figure~\ref{survival6} (right) shows the median remaining time until
@@ -11351,22 +11458,22 @@ at 14 years.
 Based on this data, young women have decreasing remaining
 ``lifetimes''.  Mechanical components with this property are called {\bf NBUE}
 for ``new better than used in expectation,'' meaning that a new part is
-expected to last longer.
+expected to last longer.%
 \index{NBUE}
 
 Women older than 22 have increasing remaining time until first
 marriage.  Components with this property are called {\bf UBNE} for
 ``used better than new in expectation.''  That is, the older the part,
 the longer it is expected to last.  Newborns and cancer patients are
-also UBNE; their life expectancy increases the longer they live.
+also UBNE; their life expectancy increases the longer they live.%
 \index{UBNE}
 
 For this example I computed median, rather than mean, because the
 Cdf is incomplete; the survival curve projects that about 20\%
 of respondents will not marry before age 44.  The age of
 first marriage for these women is unknown, and might be non-existent,
-so we can't compute a mean.
-\index{Cdf}
+so we can't compute a mean.%
+\index{Cdf}%
 \index{median}
 
 I deal with these unknown values by replacing them with {\tt np.inf},
@@ -11374,7 +11481,7 @@ a special value that represents infinity.  That makes the mean
 infinity for all ages, but the median is well-defined as long as
 more than 50\% of the remaining lifetimes are finite, which is true
 until age 30.  After that it is hard to define a meaningful
-expected remaining lifetime.
+expected remaining lifetime.%
 \index{inf}
 
 Here's the code that computes and plots these functions:
@@ -11389,12 +11496,12 @@ Here's the code that computes and plots these functions:
 \end{verbatim}
 
 {\tt sf1} is the survival curve for pregnancy length;
-in this case we can use the default values for {\tt RemainingLifetime}.
+in this case we can use the default values for {\tt RemainingLifetime}.%
 \index{pregnancy length}
 
 {\tt sf2} is the survival curve for age at first marriage;
 {\tt func} is a function that takes a Pmf and computes its
-median (50th percentile).
+median (50th percentile).%
 \index{Pmf}
 
 
@@ -11405,8 +11512,8 @@ My solution to this exercise is in \verb"chap13soln.py".
 \begin{exercise}
 In NSFG Cycles 6 and 7, the variable {\tt cmdivorcx} contains the
 date of divorce for the respondent's first marriage, if applicable,
-encoded in century-months.
-\index{divorce}
+encoded in century-months.%
+\index{divorce}%
 \index{marital status}
 
 Compute the duration of marriages that have ended in divorce, and
@@ -11414,11 +11521,11 @@ the duration, so far, of marriages that are ongoing.  Estimate the
 hazard and survival curve for the duration of marriage.
 
 Use resampling to take into account sampling weights, and plot
-data from several resamples to visualize sampling error.
+data from several resamples to visualize sampling error.%
 \index{resampling}
 
 Consider dividing the respondents into groups by decade of birth,
-and possibly by age at first marriage.
+and possibly by age at first marriage.%
 \index{groupby}
 
 \end{exercise}
@@ -11429,47 +11536,47 @@ and possibly by age at first marriage.
 \begin{itemize}
 
 \item survival analysis: A set of methods for describing and
-  predicting lifetimes, or more generally time until an event occurs.
+  predicting lifetimes, or more generally time until an event occurs.%
 \index{survival analysis}
 
 \item survival curve: A function that maps from a time, $t$, to the
-  probability of surviving past $t$.
+  probability of surviving past $t$.%
 \index{survival curve}
 
 \item hazard function: A function that maps from $t$ to the fraction
-of people alive until $t$ who die at $t$.
+of people alive until $t$ who die at $t$.%
 \index{hazard function}
 
 \item Kaplan-Meier estimation: An algorithm for estimating hazard and
-survival functions.
+survival functions.%
 \index{Kaplan-Meier estimation}
 
 \item cohort: a group of subjects defined by an event, like date of
-birth, in a particular interval of time.
+birth, in a particular interval of time.%
 \index{cohort}
 
-\item cohort effect: a difference between cohorts.
+\item cohort effect: a difference between cohorts.%
 \index{cohort effect}
 
 \item NBUE: A property of expected remaining lifetime, ``New
-better than used in expectation.''
+better than used in expectation.''%
 \index{NBUE}
 
 \item UBNE: A property of expected remaining lifetime, ``Used
-better than new in expectation.''
+better than new in expectation.''%
 \index{UBNE}
 
 \end{itemize}
 
 
-\chapter{Analytic methods}
+\chapter{Analytic methods}%
 \label{analysis}
 
 This book has focused on computational methods like simulation and
 resampling, but some of the problems we solved have
-analytic solutions that can be much faster.
-\index{resampling}
-\index{analytic methods}
+analytic solutions that can be much faster.%
+\index{resampling}%
+\index{analytic methods}%
 \index{computational methods}
 
 I present some of these methods in this chapter, and explain
@@ -11481,15 +11588,15 @@ The code in this chapter is in {\tt normal.py}.  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
-\section{Normal distributions}
-\label{why_normal}
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
+\section{Normal distributions}%
+\label{why_normal}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
 \index{distribution!Gaussian}
 
 As a motivating example, let's review the problem from
-Section~\ref{gorilla}:
+Section~\ref{gorilla}:%
 \index{gorilla}
 
 \begin{quotation}
@@ -11503,14 +11610,14 @@ To answer that question, we need the sampling
 distribution of $\xbar$.  In Section~\ref{gorilla} we approximated
 this distribution by simulating the experiment (weighing
 9 gorillas), computing $\xbar$ for each simulated experiment, and
-accumulating the distribution of estimates.
-\index{standard error}
+accumulating the distribution of estimates.%
+\index{standard error}%
 \index{standard deviation}
 
 The result is an approximation of the sampling distribution.  Then we
 use the sampling distribution to compute standard errors and
-confidence intervals:
-\index{confidence interval}
+confidence intervals:%
+\index{confidence interval}%
 \index{sampling distribution}
 
 \begin{enumerate}
@@ -11532,8 +11639,9 @@ take advantage of the fact that the weights of adult female gorillas
 are roughly normally distributed.  Normal distributions have two
 properties that make them amenable for analysis: they are ``closed'' under
 linear transformation and addition.  To explain what that means, I
-need some notation.  \index{analysis}
-\index{linear transformation}
+need some notation.%
+\index{analysis}%
+\index{linear transformation}%
 \index{addition, closed under}
 
 If the distribution of a quantity, $X$, is
@@ -11578,9 +11686,9 @@ and in general if we draw $n$ values of $X$ and add them up, we have
 
 Now we have everything we need to compute the sampling distribution of
 $\xbar$.  Remember that we compute $\xbar$ by weighing $n$ gorillas,
-adding up the total weight, and dividing by $n$.
-\index{sampling distribution}
-\index{gorilla}
+adding up the total weight, and dividing by $n$.%
+\index{sampling distribution}%
+\index{gorilla}%
 \index{weight}
 
 Assume that the distribution of gorilla weights, $X$, is
@@ -11602,35 +11710,35 @@ using Equation 1 with $a = 1/n$.
 The distribution of $Z$ is the sampling distribution of $\xbar$.
 The mean of $Z$ is $\mu$, which shows that $\xbar$ is an unbiased
 estimate of $\mu$.  The variance of the sampling distribution
-is $\sigma^2 / n$.
-\index{biased estimator}
+is $\sigma^2 / n$.%
+\index{biased estimator}%
 \index{estimator!biased}
 
 So the standard deviation of the sampling distribution, which is the
 standard error of the estimate, is $\sigma / \sqrt{n}$.  In the
 example, $\sigma$ is 7.5 kg and $n$ is 9, so the standard error is 2.5
 kg.  That result is consistent with what we estimated by simulation,
-but much faster to compute!
-\index{standard error}
+but much faster to compute!%
+\index{standard error}%
 \index{standard deviation}
 
 We can also use the sampling distribution to compute confidence
 intervals.  A 90\% confidence interval for $\xbar$ is the interval
 between the 5th and 95th percentiles of $Z$.  Since $Z$ is normally
 distributed, we can compute percentiles by evaluating the inverse
-CDF.
-\index{inverse CDF}
-\index{CDF, inverse}
+CDF.%
+\index{inverse CDF}%
+\index{CDF, inverse}%
 \index{confidence interval}
 
 There is no closed form for the CDF of the normal distribution
 or its inverse, but there are fast numerical methods and they
 are implemented in SciPy, as we saw in Section~\ref{normal}.
 {\tt thinkstats2} provides a wrapper function that makes the
-SciPy function a little easier to use:
-\index{SciPy}
-\index{normal distribution}
-\index{wrapper}
+SciPy function a little easier to use:%
+\index{SciPy}%
+\index{normal distribution}%
+\index{wrapper}%
 \index{closed form}
 
 \begin{verbatim}
@@ -11641,7 +11749,7 @@ def EvalNormalCdfInverse(p, mu=0, sigma=1):
 Given a probability, {\tt p}, it returns the corresponding
 percentile from a normal distribution with parameters {\tt mu}
 and {\tt sigma}.  For the 90\% confidence interval of $\xbar$,
-we compute the 5th and 95th percentiles like this:
+we compute the 5th and 95th percentiles like this:%
 \index{percentile}
 
 \begin{verbatim}
@@ -11655,7 +11763,7 @@ we compute the 5th and 95th percentiles like this:
 So if we run the experiment many times, we expect the
 estimate, $\xbar$, to fall in the range $(85.9, 94.1)$ about
 90\% of the time.  Again, this is consistent with the result
-we got by simulation.
+we got by simulation.%
 \index{simulation}
 
 
@@ -11664,7 +11772,7 @@ we got by simulation.
 To make these calculations easier, I have defined a class called
 {\tt Normal} that represents a normal distribution and encodes
 the equations in the previous sections.  Here's what it looks
-like:
+like:%
 \index{Normal}
 
 \begin{verbatim}
@@ -11679,7 +11787,7 @@ class Normal(object):
 \end{verbatim}
 
 So we can instantiate a Normal that represents the distribution
-of gorilla weights:
+of gorilla weights:%
 \index{gorilla}
 
 \begin{verbatim}
@@ -11709,8 +11817,8 @@ Equation 1:
 \end{verbatim}
 
 So we can compute the sampling distribution of the mean with sample
-size 9:
-\index{sampling distribution}
+size 9:%
+\index{sampling distribution}%
 \index{sample size}
 
 \begin{verbatim}
@@ -11721,8 +11829,8 @@ size 9:
 
 The standard deviation of the sampling distribution is 2.5 kg, as we
 saw in the previous section.  Finally, Normal provides {\tt
-  Percentile}, which we can use to compute a confidence interval:
-\index{standard deviation}
+  Percentile}, which we can use to compute a confidence interval:%
+\index{standard deviation}%
 \index{confidence interval}
 
 \begin{verbatim}
@@ -11735,17 +11843,19 @@ class again later, but before we go on, we need one more bit of
 analysis.
 
 
-\section{Central limit theorem}
+\section{Central limit theorem}%
 \label{CLT}
 
 As we saw in the previous sections, if we add values drawn from normal
 distributions, the distribution of the sum is normal.
 Most other distributions don't have this property;
 if we add values drawn from other distributions, the sum does not
-generally have an analytic distribution.
-  \index{sum}
-\index{normal distribution} \index{distribution!normal}
-\index{Gaussian distribution} \index{distribution!Gaussian}
+generally have an analytic distribution.%
+\index{sum}%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
+\index{distribution!Gaussian}
 
 But if we add up {\tt n} values from
 almost any distribution, the distribution of the sum converges to
@@ -11753,42 +11863,42 @@ normal as {\tt n} increases.
 
 More specifically, if the distribution of the values has mean and
 standard deviation $\mu$ and $\sigma$, the distribution of the sum is
-approximately $\normal(n \mu, n \sigma^2)$.
+approximately $\normal(n \mu, n \sigma^2)$.%
 \index{standard deviation}
 
 This result is the Central Limit Theorem (CLT).  It is one of the
 most useful tools for statistical analysis, but it comes with
-caveats:
-\index{Central Limit Theorem}
+caveats:%
+\index{Central Limit Theorem}%
 \index{CLT}
 
 \begin{itemize}
 
 \item The values have to be drawn independently.  If they are
 correlated, the CLT doesn't apply (although this is seldom a problem
-in practice).
+in practice).%
 \index{independent}
 
 \item The values have to come from the same distribution (although
-  this requirement can be relaxed).
+  this requirement can be relaxed).%
 \index{identical}
 
 \item The values have to be drawn
   from a distribution with finite mean and variance.  So most Pareto
-  distributions are out.
-\index{mean}
-\index{variance}
-\index{Pareto distribution}
-\index{distribution!Pareto}
-\index{exponential distribution}
+  distributions are out.%
+\index{mean}%
+\index{variance}%
+\index{Pareto distribution}%
+\index{distribution!Pareto}%
+\index{exponential distribution}%
 \index{distribution!exponential}
 
 \item The rate of convergence depends
   on the skewness of the distribution.  Sums from an exponential
   distribution converge for small {\tt n}.  Sums from a
-  lognormal distribution require larger sizes.
-\index{lognormal distribution}
-\index{distribution!lognormal}
+  lognormal distribution require larger sizes.%
+\index{lognormal distribution}%
+\index{distribution!lognormal}%
 \index{skewness}
 
 \end{itemize}
@@ -11798,12 +11908,12 @@ of normal distributions in the natural world.  Many characteristics of
 living things are affected by genetic
 and environmental factors whose effect is additive.  The characteristics
 we measure are the sum of a large number of small effects, so their
-distribution tends to be normal.
-\index{normal distribution}
-\index{distribution!normal}
-\index{Gaussian distribution}
-\index{distribution!Gaussian}
-\index{Central Limit Theorem}
+distribution tends to be normal.%
+\index{normal distribution}%
+\index{distribution!normal}%
+\index{Gaussian distribution}%
+\index{distribution!Gaussian}%
+\index{Central Limit Theorem}%
 \index{CLT}
 
 
@@ -11832,7 +11942,7 @@ is the number of sums to generate.
 To explain this function, I'll start from the inside and work my way
 out.  Each time we call {\tt np.random.exponential}, we get a sequence
 of {\tt n} exponential values and compute its sum.  {\tt sample}
-is a list of these sums, with length {\tt iters}.
+is a list of these sums, with length {\tt iters}.%
 \index{NumPy}
 
 It is easy to get {\tt n} and {\tt iters} confused:  {\tt n} is the
@@ -11840,8 +11950,8 @@ number of terms in each sum;  {\tt iters} is the number of sums we
 compute in order to characterize the distribution of sums.
 
 The return value is a list of {\tt (n, sample)} pairs.  For
-each pair, we make a normal probability plot:
-\index{thinkplot}
+each pair, we make a normal probability plot:%
+\index{thinkplot}%
 \index{normal probability plot}
 
 \begin{verbatim}
@@ -11855,14 +11965,14 @@ def NormalPlotSamples(samples, plot=1, ylabel=''):
 \end{verbatim}
 
 {\tt NormalPlotSamples} takes the list of pairs from {\tt
-  MakeExpoSamples} and generates a row of normal probability plots.
+  MakeExpoSamples} and generates a row of normal probability plots.%
 \index{normal probability plot}
 
 \begin{figure}
 % normal.py
 \centerline{\includegraphics[height=3.5in]{figs/normal1.pdf}}
 \caption{Distributions of sums of exponential values (top row) and
-lognormal values (bottom row).}
+lognormal values (bottom row).}%
 \label{normal1}
 \end{figure}
 
@@ -11878,16 +11988,16 @@ lognormal distribution.  Lognormal distributions are generally more
 skewed than exponential distributions, so the distribution of sums
 takes longer to converge.  With {\tt n=10} the normal
 probability plot is nowhere near straight, but with {\tt n=100}
-it is approximately normal.
-\index{lognormal distribution}
-\index{distribution!lognormal}
+it is approximately normal.%
+\index{lognormal distribution}%
+\index{distribution!lognormal}%
 \index{skewness}
 
 \begin{figure}
 % normal.py
 \centerline{\includegraphics[height=3.5in]{figs/normal2.pdf}}
 \caption{Distributions of sums of Pareto values (top row) and
-correlated exponential values (bottom row).}
+correlated exponential values (bottom row).}%
 \label{normal2}
 \end{figure}
 
@@ -11896,11 +12006,11 @@ on the parameters, many Pareto distributions do not have finite mean
 and variance.  As a result, the Central Limit Theorem does not apply.
 Figure~\ref{normal2} (top row) shows distributions of sums of
 Pareto values.  Even with {\tt n=100} the normal probability plot
-is far from straight.
-\index{Pareto distribution}
-\index{distribution!Pareto}
-\index{Central Limit Theorem}
-\index{CLT}
+is far from straight.%
+\index{Pareto distribution}%
+\index{distribution!Pareto}%
+\index{Central Limit Theorem}%
+\index{CLT}%
 \index{normal probability plot}
 
 I also mentioned that CLT does not apply if the values are correlated.
@@ -11908,14 +12018,14 @@ To test that, I generate correlated values from an exponential
 distribution.  The algorithm for generating correlated values is
 (1) generate correlated normal values, (2) use the normal CDF
 to transform the values to uniform, and (3) use the inverse
-exponential CDF to transform the uniform values to exponential.
-\index{inverse CDF}
-\index{CDF, inverse}
-\index{correlation}
+exponential CDF to transform the uniform values to exponential.%
+\index{inverse CDF}%
+\index{CDF, inverse}%
+\index{correlation}%
 \index{random number}
 
 {\tt GenerateCorrelated} returns an iterator of {\tt n} normal values
-with serial correlation {\tt rho}:
+with serial correlation {\tt rho}:%
 \index{iterator}
 
 \begin{verbatim}
@@ -11933,8 +12043,8 @@ The first value is a standard normal value.  Each subsequent value
 depends on its predecessor: if the previous value is {\tt x}, the mean of
 the next value is {\tt x*rho}, with variance {\tt 1-rho**2}.  Note that {\tt
   random.gauss} takes the standard deviation as the second argument,
-not variance.
-\index{standard deviation}
+not variance.%
+\index{standard deviation}%
 \index{standard normal distribution}
 
 {\tt GenerateExpoCorrelated}
@@ -11952,9 +12062,9 @@ def GenerateExpoCorrelated(rho, n):
 is a sequence of uniform values between 0 and 1.  {\tt expo} is
 a correlated sequence of exponential values.
 {\tt ppf} stands for ``percent point function,'' which is another
-name for the inverse CDF.
-\index{inverse CDF}
-\index{CDF, inverse}
+name for the inverse CDF.%
+\index{inverse CDF}%
+\index{CDF, inverse}%
 \index{percent point function}
 
 Figure~\ref{normal2} (bottom row) shows distributions of sums of
@@ -11962,8 +12072,8 @@ correlated exponential values with {\tt rho=0.9}.  The correlation
 slows the rate of convergence; nevertheless, with {\tt n=100} the
 normal probability plot is nearly straight.  So even though CLT
 does not strictly apply when the values are correlated, moderate
-correlations are seldom a problem in practice.
-\index{normal probability plot}
+correlations are seldom a problem in practice.%
+\index{normal probability plot}%
 \index{correlation}
 
 These experiments are meant to show how the Central Limit Theorem
@@ -11971,16 +12081,16 @@ works, and what happens when it doesn't.  Now let's see how we can
 use it.
 
 
-\section{Applying the CLT}
+\section{Applying the CLT}%
 \label{usingCLT}
 
 To see why the Central Limit Theorem is useful, let's get back
 to the example in Section~\ref{testdiff}: testing the apparent
 difference in mean pregnancy length for first babies and others.
 As we've seen, the apparent difference is about
-0.078 weeks:
-\index{pregnancy length}
-\index{Central Limit Theorem}
+0.078 weeks:%
+\index{pregnancy length}%
+\index{Central Limit Theorem}%
 \index{CLT}
 
 \begin{verbatim}
@@ -11992,15 +12102,15 @@ As we've seen, the apparent difference is about
 Remember the logic of hypothesis testing: we compute a p-value, which
 is the probability of the observed difference under the null
 hypothesis; if it is small, we conclude that the observed difference
-is unlikely to be due to chance.
-\index{p-value}
-\index{null hypothesis}
+is unlikely to be due to chance.%
+\index{p-value}%
+\index{null hypothesis}%
 \index{hypothesis testing}
 
 In this example, the null hypothesis is that the distribution of
 pregnancy lengths is the same for first babies and others.  
 So we can compute the sampling distribution of the mean
-like this:
+like this:%
 \index{sampling distribution}
 
 \begin{verbatim}
@@ -12028,13 +12138,13 @@ In this example, the data are not normally distributed, so this
 approximation is not very good.  But then we compute {\tt dist.Sum(n)
   / n}, which is the sampling distribution of the mean of {\tt n}
 values.  Even if the data are not normally distributed, the sampling
-distribution of the mean is, by the Central Limit Theorem.
-\index{Central Limit Theorem}
+distribution of the mean is, by the Central Limit Theorem.%
+\index{Central Limit Theorem}%
 \index{CLT}
 
 Next, we compute the sampling distribution of the difference
 in the means.  The {\tt Normal} class knows how to perform
-subtraction using Equation 2:
+subtraction using Equation 2:%
 \index{Normal}
 
 \begin{verbatim}
@@ -12052,12 +12162,12 @@ N(0, 0.0032)
 
 The mean is 0, which makes sense because we expect two samples from
 the same distribution to have the same mean, on average.  The variance
-of the sampling distribution is 0.0032.
+of the sampling distribution is 0.0032.%
 \index{sampling distribution}
 
 {\tt Normal} provides {\tt Prob}, which evaluates the normal CDF.
 We can use {\tt Prob} to compute the probability of a
-difference as large as {\tt delta} under the null hypothesis:
+difference as large as {\tt delta} under the null hypothesis:%
 \index{null hypothesis}
 
 \begin{verbatim}
@@ -12066,9 +12176,9 @@ difference as large as {\tt delta} under the null hypothesis:
 \end{verbatim}
 
 Which means that the p-value for a one-sided test is 0.84.  For
-a two-sided test we would also compute
-\index{p-value}
-\index{one-sided test}
+a two-sided test we would also compute%
+\index{p-value}%
+\index{one-sided test}%
 \index{two-sided test}
 
 \begin{verbatim}
@@ -12078,7 +12188,7 @@ a two-sided test we would also compute
 
 Which is the same because the normal distribution is symmetric.
 The sum of the tails is 0.168, which is consistent with the estimate
-in Section~\ref{testdiff}, which was 0.17.
+in Section~\ref{testdiff}, which was 0.17.%
 \index{symmetric}
 
 
@@ -12087,12 +12197,13 @@ in Section~\ref{testdiff}, which was 0.17.
 
 In Section~\ref{corrtest} we used a permutation test for the correlation
 between birth weight and mother's age, and found that it is
-statistically significant, with p-value less than 0.001.
-\index{p-value}
-\index{birth weight}
-\index{weight!birth}
-\index{permutation}
-  \index{significant} \index{statistically significant}
+statistically significant, with p-value less than 0.001.%
+\index{p-value}%
+\index{birth weight}%
+\index{weight!birth}%
+\index{permutation}%
+\index{significant}%
+\index{statistically significant}
 
 Now we can do the same thing analytically.  The method is based
 on this mathematical result: given two variables that are normally distributed
@@ -12104,16 +12215,16 @@ correlation
 %
 the distribution of $t$ is Student's t-distribution with parameter
 $n-2$.  The t-distribution is an analytic distribution; the CDF can
-be computed efficiently using gamma functions.
-\index{Pearson coefficient of correlation}
+be computed efficiently using gamma functions.%
+\index{Pearson coefficient of correlation}%
 \index{correlation}
 
 We can use this result to compute the sampling distribution of
 correlation under the null hypothesis; that is, if we generate
 uncorrelated sequences of normal values, what is the distribution of
 their correlation?  {\tt StudentCdf} takes the sample size, {\tt n}, and
-returns the sampling distribution of correlation:
-\index{null hypothesis}
+returns the sampling distribution of correlation:%
+\index{null hypothesis}%
 \index{sampling distribution}
 
 \begin{verbatim}
@@ -12130,18 +12241,18 @@ computed using the CDF of the Student's t-distribution implemented in
 SciPy.  The parameter of the t-distribution, {\tt df}, stands for
 ``degrees of freedom.''  I won't explain that term, but you can read
 about it at
-\url{http://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)}.
-\index{NumPy}
-\index{SciPy}
-\index{Student's t-distribution}
-\index{distribution!Student's t}
+\url{http://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)}.%
+\index{NumPy}%
+\index{SciPy}%
+\index{Student's t-distribution}%
+\index{distribution!Student's t}%
 \index{degrees of freedom}
 
 \begin{figure}
 % normal.py
 \centerline{\includegraphics[height=2.5in]{figs/normal4.pdf}}
 \caption{Sampling distribution of correlations for uncorrelated
-normal variables.}
+normal variables.}%
 \label{normal4}
 \end{figure}
 
@@ -12156,16 +12267,16 @@ we generated in Section~\ref{corrtest} by resampling.  They are nearly
 identical.  Although the actual distributions are not normal, 
 Pearson's coefficient of correlation is based on sample means
 and variances.  By the Central Limit Theorem, these moment-based
-statistics are normally distributed even if the data are not.
-\index{Central Limit Theorem}
-\index{CLT}
-\index{null hypothesis}
+statistics are normally distributed even if the data are not.%
+\index{Central Limit Theorem}%
+\index{CLT}%
+\index{null hypothesis}%
 \index{resampling}
 
 From Figure~\ref{normal4}, we can see that the
 observed correlation, 0.07, is unlikely to occur if the variables
 are actually uncorrelated.
-Using the analytic distribution, we can compute just how unlikely:
+Using the analytic distribution, we can compute just how unlikely:%
 \index{analytic distribution}
 
 \begin{verbatim}
@@ -12177,8 +12288,8 @@ We compute the value of {\tt t} that corresponds to {\tt r=0.07}, and
 then evaluate the t-distribution at {\tt t}.  The result is {\tt
   2.9e-11}.  This example demonstrates an advantage of the analytic
 method: we can compute very small p-values.  But in practice it
-usually doesn't matter.
-\index{SciPy}
+usually doesn't matter.%
+\index{SciPy}%
 \index{p-value}
 
 
@@ -12194,25 +12305,25 @@ One reason the chi-squared statistic is widely used is that
 its sampling distribution under the null hypothesis is analytic;
 by a remarkable coincidence\footnote{Not really.}, it is called
 the chi-squared distribution.  Like the t-distribution, the
-chi-squared CDF can be computed efficiently using gamma functions.
-\index{deviation}
-\index{null hypothesis}
-\index{sampling distribution}
-\index{chi-squared test}
-\index{chi-squared distribution}
+chi-squared CDF can be computed efficiently using gamma functions.%
+\index{deviation}%
+\index{null hypothesis}%
+\index{sampling distribution}%
+\index{chi-squared test}%
+\index{chi-squared distribution}%
 \index{distribution!chi-squared}
 
 \begin{figure}
 % normal.py
 \centerline{\includegraphics[height=2.5in]{figs/normal5.pdf}}
 \caption{Sampling distribution of chi-squared statistics for
-a fair six-sided die.}
+a fair six-sided die.}%
 \label{normal5}
 \end{figure}
 
 SciPy provides an implementation of the chi-squared distribution,
 which we use to compute the sampling distribution of the
-chi-squared statistic:
+chi-squared statistic:%
 \index{SciPy}
 
 \begin{verbatim}
@@ -12225,13 +12336,13 @@ def ChiSquaredCdf(n):
 Figure~\ref{normal5} shows the analytic result along with the
 distribution we got by resampling.  They are very similar,
 especially in the tail, which is the part we usually care most
-about.
-\index{resampling}
+about.%
+\index{resampling}%
 \index{tail}
 
 We can use this distribution to compute the p-value of the
-observed test statistic, {\tt chi2}:
-\index{test statistic}
+observed test statistic, {\tt chi2}:%
+\index{test statistic}%
 \index{p-value}
 
 \begin{verbatim}
@@ -12246,16 +12357,16 @@ freedom'' again.  In this case the correct parameter is {\tt n-1},
 where {\tt n} is the size of the table, 6.  Choosing this parameter
 can be tricky; to be honest, I am never confident that I have it
 right until I generate something like Figure~\ref{normal5} to compare
-the analytic results to the resampling results.
+the analytic results to the resampling results.%
 \index{degrees of freedom}
 
 
 \section{Discussion}
 
 This book focuses on computational methods like resampling and
-permutation.  These methods have several advantages over analysis:
-\index{resampling}
-\index{permutation}
+permutation.  These methods have several advantages over analysis:%
+\index{resampling}%
+\index{permutation}%
 \index{computational methods}
 
 \begin{itemize}
@@ -12265,14 +12376,14 @@ permutation.  These methods have several advantages over analysis:
   hypothesis testing.  Many students don't really understand what
   p-values are.  I think the approach I presented in
   Chapter~\ref{testing}---simulating the null hypothesis and
-  computing test statistics---makes the fundamental idea clearer.
-\index{p-value}
+  computing test statistics---makes the fundamental idea clearer.%
+\index{p-value}%
 \index{null hypothesis}
 
 \item They are robust and versatile.  Analytic methods are often based
   on assumptions that might not hold in practice.  Computational
   methods require fewer assumptions, and can be adapted and extended
-  more easily.
+  more easily.%
 \index{robust}
 
 \item They are debuggable.  Analytic methods are often like a black
@@ -12280,7 +12391,7 @@ permutation.  These methods have several advantages over analysis:
   to make subtle errors, hard to be confident that the results are
   right, and hard to find the problem if they are not.  Computational
   methods lend themselves to incremental development and testing,
-  which fosters confidence in the results.
+  which fosters confidence in the results.%
 \index{debugging}
 
 \end{itemize}
@@ -12291,7 +12402,7 @@ into account these pros and cons, I recommend the following process:
 \begin{enumerate}
 
 \item Use computational methods during exploration.  If you find a
-  satisfactory answer and the run time is acceptable, you can stop.
+  satisfactory answer and the run time is acceptable, you can stop.%
 \index{exploration}
 
 \item If run time is not acceptable, look for opportunities to
@@ -12301,7 +12412,7 @@ into account these pros and cons, I recommend the following process:
 \item If replacing a computational method with an analytic method is
   appropriate, use the computational method as a basis of comparison, 
   providing mutual validation between the computational and
-  analytic results.
+  analytic results.%
 \index{model}
 
 \end{enumerate}
@@ -12314,7 +12425,7 @@ to go past Step 1.
 
 A solution to these exercises is in \verb"chap14soln.py"
 
-\begin{exercise}
+\begin{exercise}%
 \label{log_clt}
 In Section~\ref{lognormal}, we saw that the distribution
 of adult weights is approximately lognormal.  One possible
@@ -12326,11 +12437,11 @@ of multiplicative factors:
 \[ w = w_0 f_1 f_2 ... f_n  \]
 %
 where $w$ is adult weight, $w_0$ is birth weight, and $f_i$
-is the weight gain factor for year $i$.
-\index{birth weight}
-\index{weight!birth}
-\index{lognormal distribution}
-\index{distribution!lognormal}
+is the weight gain factor for year $i$.%
+\index{birth weight}%
+\index{weight!birth}%
+\index{lognormal distribution}%
+\index{distribution!lognormal}%
 \index{adult weight}
 
 The log of a product is the sum of the logs of the
@@ -12340,8 +12451,8 @@ factors:
 %
 So by the Central Limit Theorem, the distribution of $\log w$ is
 approximately normal for large $n$, which implies that the
-distribution of $w$ is lognormal.
-\index{Central Limit Theorem}
+distribution of $w$ is lognormal.%
+\index{Central Limit Theorem}%
 \index{CLT}
 
 To model this phenomenon, choose a distribution for $f$ that seems
@@ -12349,10 +12460,9 @@ reasonable, then generate a sample of adult weights by choosing a
 random value from the distribution of birth weights, choosing a
 sequence of factors from the distribution of $f$, and computing the
 product.  What value of $n$ is needed to converge to a lognormal
-distribution?
-\index{model}
-
-\index{logarithm}
+distribution?%
+\index{model}%
+\index{logarithm}%
 \index{product}
 
 \end{exercise}
@@ -12363,17 +12473,17 @@ distribution?
 In Section~\ref{usingCLT} we used the Central Limit Theorem to find
 the sampling distribution of the difference in means, $\delta$, under
 the null hypothesis that both samples are drawn from the same
-population.
-\index{null hypothesis}
+population.%
+\index{null hypothesis}%
 \index{sampling distribution}
 
 We can also use this distribution to find the standard error of the
 estimate and confidence intervals, but that would only be
 approximately correct.  To be more precise, we should compute the
 sampling distribution of $\delta$ under the alternate hypothesis that
-the samples are drawn from different populations.
-\index{standard error}
-\index{standard deviation}
+the samples are drawn from different populations.%
+\index{standard error}%
+\index{standard deviation}%
 \index{confidence interval}
 
 Compute this distribution and use it to calculate the standard error
@@ -12396,25 +12506,27 @@ a 7-point scale.
 Before the intervention, male students reported higher scores for the
 programming aspect of the project than female students; on average men
 reported a score of 3.57 with standard error 0.28.  Women reported
-1.91, on average, with standard error 0.32.
+1.91, on average, with standard error 0.32.%
 \index{standard error}
 
 Compute the sampling distribution of the gender gap (the difference in
 means), and test whether it is statistically significant.  Because you
 are given standard errors for the estimated means, you don't need to
-know the sample size to figure out the sampling distributions.
-  \index{significant} \index{statistically significant}
+know the sample size to figure out the sampling distributions.%
+\index{significant}%
+\index{statistically significant}%
 \index{sampling distribution}
 
 After the intervention, the gender gap was smaller: the average score
 for men was 3.44 (SE 0.16); the average score for women was 3.18 (SE
 0.16).  Again, compute the sampling distribution of the gender gap and
-test it.
+test it.%
 \index{gender gap}
 
 Finally, estimate the change in gender gap; what is the sampling
-distribution of this change, and is it statistically significant?
-  \index{significant} \index{statistically significant}
+distribution of this change, and is it statistically significant?%
+\index{significant}%
+\index{statistically significant}
 \end{exercise}
 
 \cleardoublepage


### PR DESCRIPTION
A large number of indexing and cross referencing errors were fixed by
removing spaces and commenting out newlines between the target and the
index/label markers.

For example, in the original, the index ref for 'population' erroneously
takes you to page 4 rather than page 3.