### PR TITLE
Prefer inline \verb"" to {\tt} expressions

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -507,7 +507,7 @@ that include these packages.
 \index{installation}
 
 After you clone the repository or unzip the zip file, you should have
-a folder called {\tt ThinkStats2/code} with a file called {nsfg.py}.
+a folder called \verb"ThinkStats2/code" with a file called {nsfg.py}.
 If you run {nsfg.py}, it should read a data file, run some tests, and print a
 message like, ``All tests passed.''  If you get import errors, it
 probably means there are packages you need to install.
@@ -545,7 +545,7 @@ the Franklin W. Olin College of Engineering in Needham, MA.
 \section*{Contributor List}
 
 If you have a suggestion or correction, please send email to 
-{\tt downey@allendowney.com}.  If I make a change based on your
+\verb"downey@allendowney.com".  If I make a change based on your
 feedback, I will add you to the contributor list
 (unless you ask to be omitted).
 \index{contributors}
@@ -837,22 +837,22 @@ The code and data used in this book are available from
 about downloading and working with this code, 
 see Section~\ref{code}.
 
-Once you download the code, you should have a file called {\tt
-  ThinkStats2/code/nsfg.py}.  If you run it, it should read a data
+Once you download the code, you should have a file called
+\verb"ThinkStats2/code/nsfg.py".  If you run it, it should read a data
 file, run some tests, and print a message like, ``All tests passed.''
 
 Let's see what it does.  Pregnancy data from Cycle 6 of the NSFG is in
-a file called {\tt 2002FemPreg.dat.gz}; it
+a file called \verb"2002FemPreg.dat.gz"; it
 is a gzip-compressed data file in plain text (ASCII), with fixed width
 columns.  Each line in the file is a {\bf record} that
 contains data about one pregnancy.
 
-The format of the file is documented in {\tt 2002FemPreg.dct}, which
+The format of the file is documented in \verb"2002FemPreg.dct", which
 is a Stata dictionary file.  Stata is a statistical software system;
 a ``dictionary'' in this context is a list of variable names, types,
 and indices that identify where in each line to find each variable.
 
-For example, here are a few lines from {\tt 2002FemPreg.dct}:
+For example, here are a few lines from \verb"2002FemPreg.dct":
 %
 \begin{verbatim}
 infile dictionary {
@@ -861,16 +861,16 @@ infile dictionary {
 }
 \end{verbatim}
 
-This dictionary describes two variables: {\tt caseid} is a 12-character
-string that represents the respondent ID; {\tt pregordr} is a 
+This dictionary describes two variables: \verb"caseid" is a 12-character
+string that represents the respondent ID; \verb"pregordr" is a 
 one-byte integer that indicates which pregnancy this record
 describes for this respondent.
 
-The code you downloaded includes {\tt thinkstats2.py}, which is a Python
+The code you downloaded includes \verb"thinkstats2.py", which is a Python
 module
 that contains many classes and functions used in this book,
 including functions that read the Stata dictionary and
-the NSFG data file.  Here's how they are used in {\tt nsfg.py}:
+the NSFG data file.  Here's how they are used in \verb"nsfg.py":
 
 \begin{verbatim}
 def ReadFemPreg(dct_file='2002FemPreg.dct',
@@ -881,16 +881,16 @@ def ReadFemPreg(dct_file='2002FemPreg.dct',
     return df
 \end{verbatim}
 
-{\tt ReadStataDct} takes the name of the dictionary file
-and returns {\tt dct}, a {\tt FixedWidthVariables} object that contains the
-information from the dictionary file.  {\tt dct} provides {\tt
-  ReadFixedWidth}, which reads the data file.
+\verb"ReadStataDct" takes the name of the dictionary file
+and returns \verb"dct", a \verb"FixedWidthVariables" object that contains the
+information from the dictionary file.  \verb"dct" provides
+\verb"ReadFixedWidth", which reads the data file.
 
 
 \section{DataFrames}
 \label{dataframe}
 
-The result of {\tt ReadFixedWidth} is a DataFrame, which is the
+The result of \verb"ReadFixedWidth" is a DataFrame, which is the
 fundamental data structure provided by pandas, which is a Python
 data and statistics package we'll use throughout this book.
 A DataFrame contains a
@@ -903,7 +903,7 @@ In addition to the data, a DataFrame also contains the variable
 names and their types, and it provides methods for accessing and modifying
 the data.
 
-If you print {\tt df} you get a truncated view of the rows and
+If you print \verb"df" you get a truncated view of the rows and
 columns, and the shape of the DataFrame, which is 13593
 rows/records and 244 columns/variables.
 
@@ -918,7 +918,7 @@ rows/records and 244 columns/variables.
 The DataFrame is too big to display, so the output is truncated.  The
 last line reports the number of rows and columns.
 
-The attribute {\tt columns} returns a sequence of column
+The attribute \verb"columns" returns a sequence of column
 names as Unicode strings:
 
 \begin{verbatim}
@@ -971,8 +971,8 @@ general they can be any sortable type.  The elements
 are also integers, but they can be any type.
 
 The last line includes the variable name, Series length, and data type;
-{\tt int64} is one of the types provided by NumPy.  If you run
-this example on a 32-bit machine you might see {\tt int32}.
+\verb"int64" is one of the types provided by NumPy.  If you run
+this example on a 32-bit machine you might see \verb"int32".
 \index{NumPy}
 
 You can access the elements of a Series using integer indices
@@ -988,7 +988,7 @@ and slices:
 Name: pregordr, dtype: int64
 \end{verbatim}
 
-The result of the index operator is an {\tt int64}; the
+The result of the index operator is an \verb"int64"; the
 result of the slice is another Series.
 
 You can also access the columns of a DataFrame using dot notation:
@@ -1004,26 +1004,26 @@ identifier, so it has to begin with a letter, can't contain spaces, etc.
 
 \section{Variables}
 
-We have already seen two variables in the NSFG dataset, {\tt caseid}
-and {\tt pregordr}, and we have seen that there are 244 variables in
+We have already seen two variables in the NSFG dataset, \verb"caseid"
+and \verb"pregordr", and we have seen that there are 244 variables in
 total.  For the explorations in this book, I use the following
 variables:
 
 \begin{itemize}
 
-\item {\tt caseid} is the integer ID of the respondent.
+\item \verb"caseid" is the integer ID of the respondent.
 
-\item {\tt prglngth} is the integer duration of the pregnancy in weeks.
+\item \verb"prglngth" is the integer duration of the pregnancy in weeks.
 \index{pregnancy length}
 
-\item {\tt outcome} is an integer code for the outcome of the
+\item \verb"outcome" is an integer code for the outcome of the
   pregnancy.  The code 1 indicates a live birth.
 
-\item {\tt pregordr} is a pregnancy serial number; for example, the
+\item \verb"pregordr" is a pregnancy serial number; for example, the
   code for a respondent's first pregnancy is 1, for the second
   pregnancy is 2, and so on.
 
-\item {\tt birthord} is a serial number for live
+\item \verb"birthord" is a serial number for live
   births; the code for a respondent's first child is 1, and so on.
   For outcomes other than live birth, this field is blank.
 
@@ -1032,9 +1032,9 @@ variables:
 \index{birth weight}
 \index{weight!birth}
 
-\item {\tt agepreg} is the mother's age at the end of the pregnancy.
+\item \verb"agepreg" is the mother's age at the end of the pregnancy.
 
-\item {\tt finalwgt} is the statistical weight associated with the
+\item \verb"finalwgt" is the statistical weight associated with the
   respondent.  It is a floating-point value that indicates the number
   of people in the U.S. population this respondent represents.
   \index{weight!sample}
@@ -1046,9 +1046,9 @@ variables are {\bf recodes}, which means that they are not part of the
 {\bf raw data} collected by the survey; they are calculated using
 the raw data.  \index{recode} \index{raw data}
 
-For example, {\tt prglngth} for live births is equal to the raw
-variable {\tt wksgest} (weeks of gestation) if it is available;
-otherwise it is estimated using {\tt mosgest * 4.33} (months of
+For example, \verb"prglngth" for live births is equal to the raw
+variable \verb"wksgest" (weeks of gestation) if it is available;
+otherwise it is estimated using \verb"mosgest * 4.33" (months of
 gestation times the average number of weeks in a month).
 
 Recodes are often based on logic that checks the consistency and
@@ -1064,7 +1064,7 @@ When you import data like this, you often have to check for errors,
 deal with special values, convert data into different formats, and
 perform calculations.  These operations are called {\bf data cleaning}.
 
-{\tt nsfg.py} includes {\tt CleanFemPreg}, a function that cleans
+\verb"nsfg.py" includes \verb"CleanFemPreg", a function that cleans
 the variables I am planning to use.
 
 \begin{verbatim}
@@ -1078,10 +1078,10 @@ def CleanFemPreg(df):
     df['totalwgt_lb'] = df.birthwgt_lb + df.birthwgt_oz / 16.0    
 \end{verbatim}
 
-{\tt agepreg} contains the mother's age at the end of the
-pregnancy.  In the data file, {\tt agepreg} is encoded as an integer
+\verb"agepreg" contains the mother's age at the end of the
+pregnancy.  In the data file, \verb"agepreg" is encoded as an integer
 number of centiyears.  So the first line divides each element
-of {\tt agepreg} by 100, yielding a floating-point value in
+of \verb"agepreg" by 100, yielding a floating-point value in
 years.
 
 \verb"birthwgt_lb" and \verb"birthwgt_oz" contain the weight of the
@@ -1096,14 +1096,14 @@ In addition it uses several special codes:
 
 Special values encoded as numbers are {\em dangerous\/} because if they
 are not handled properly, they can generate bogus results, like
-a 99-pound baby.  The {\tt replace} method replaces these values with
-{\tt np.nan}, a special floating-point value that represents ``not a
-number.''  The {\tt inplace} flag tells {\tt replace} to modify the
+a 99-pound baby.  The \verb"replace" method replaces these values with
+\verb"np.nan", a special floating-point value that represents ``not a
+number.''  The \verb"inplace" flag tells \verb"replace" to modify the
 existing Series rather than create a new one.
 \index{NaN}
 
 As part of the IEEE floating-point standard, all mathematical
-operations return {\tt nan} if either argument is {\tt nan}:
+operations return \verb"nan" if either argument is \verb"nan":
 
 \begin{verbatim}
 >>> import numpy as np
@@ -1111,13 +1111,13 @@ operations return {\tt nan} if either argument is {\tt nan}:
 nan
 \end{verbatim}
 
-So computations with {\tt nan} tend to do the right thing, and most
-pandas functions handle {\tt nan} appropriately.  But dealing with
+So computations with \verb"nan" tend to do the right thing, and most
+pandas functions handle \verb"nan" appropriately.  But dealing with
 missing data will be a recurring issue.
 \index{pandas}
 \index{missing values}
 
-The last line of {\tt CleanFemPreg} creates a new
+The last line of \verb"CleanFemPreg" creates a new
 column \verb"totalwgt_lb" that combines pounds and ounces into
 a single quantity, in pounds.
 
@@ -1152,7 +1152,7 @@ time to validate the data, you can save time later and avoid errors.
 One way to validate data is to compute basic statistics and compare
 them with published results.  For example, the NSFG codebook includes
 tables that summarize each variable.  Here is the table for
-{\tt outcome}, which encodes the outcome of each pregnancy:
+\verb"outcome", which encodes the outcome of each pregnancy:
 
 \begin{verbatim}
 value   label                  Total
@@ -1165,8 +1165,8 @@ value   label                  Total
 \end{verbatim}
 
 The Series class provides a method, \verb"value_counts", that
-counts the number of times each value appears.  If we select the {\tt
-  outcome} Series from the DataFrame, we can use \verb"value_counts"
+counts the number of times each value appears.  If we select the \verb"outcome"
+Series from the DataFrame, we can use \verb"value_counts"
 to compare with the published data:
 \index{DataFrame}
 \index{Series}
@@ -1186,7 +1186,7 @@ The result of \verb"value_counts" is a Series;
 appear in order.
 
 Comparing the results with the published table, it looks like the
-values in {\tt outcome} are correct.  Similarly, here is the published
+values in \verb"outcome" are correct.  Similarly, here is the published
 table for \verb"birthwgt_lb"
 
 \begin{verbatim}
@@ -1227,14 +1227,14 @@ up the counts for 0-5 and 9-95, they check out, too.  But
 if you look more closely, you will notice one value that has to be
 an error, a 51 pound baby!
 
-To deal with this error, I added a line to {\tt CleanFemPreg}:
+To deal with this error, I added a line to \verb"CleanFemPreg":
 
 \begin{verbatim}
 df.loc[df.birthwgt_lb > 20, 'birthwgt_lb'] = np.nan
 \end{verbatim}
 
-This statement replaces invalid values with {\tt np.nan}.
-The attribute {\tt loc} provides several ways to select
+This statement replaces invalid values with \verb"np.nan".
+The attribute \verb"loc" provides several ways to select
 rows and columns from a DataFrame.  In this example, the
 first expression in brackets is the row indexer; the second
 expression selects the column.
@@ -1242,7 +1242,7 @@ expression selects the column.
 \index{indexer!loc}
 
 The expression \verb"df.birthwgt_lb > 20" yields a Series of type
-{\tt bool}, where True indicates that the condition is true.  When a
+\verb"bool", where True indicates that the condition is true.  When a
 boolean Series is used as an index, it selects only the elements that
 satisfy the condition.
 \index{Series} \index{boolean} \index{NaN}
@@ -1267,15 +1267,15 @@ def MakePregMap(df):
     return d
 \end{verbatim}
 
-{\tt df} is the DataFrame with pregnancy data.  The {\tt iteritems}
+\verb"df" is the DataFrame with pregnancy data.  The \verb"iteritems"
 method enumerates the index (row number)
-and {\tt caseid} for each pregnancy.
+and \verb"caseid" for each pregnancy.
 \index{DataFrame}
 
-{\tt d} is a dictionary that maps from each case ID to a list of
-indices.  If you are not familiar with {\tt defaultdict}, it is in
-the Python {\tt collections} module.
-Using {\tt d}, we can look up a respondent and get the
+\verb"d" is a dictionary that maps from each case ID to a list of
+indices.  If you are not familiar with \verb"defaultdict", it is in
+the Python \verb"collections" module.
+Using \verb"d", we can look up a respondent and get the
 indices of that respondent's pregnancies.
 
 This example looks up one respondent and prints a list of outcomes
@@ -1289,17 +1289,17 @@ for her pregnancies:
 [4 4 4 4 4 4 1]
 \end{verbatim}
 
-{\tt indices} is the list of indices for pregnancies corresponding
-to respondent {\tt 10229}.
+\verb"indices" is the list of indices for pregnancies corresponding
+to respondent \verb"10229".
 
-Using this list as an index into {\tt df.outcome} selects the
+Using this list as an index into \verb"df.outcome" selects the
 indicated rows and yields a Series.  Instead of printing the
-whole Series, I selected the {\tt values} attribute, which is
+whole Series, I selected the \verb"values" attribute, which is
 a NumPy array.  
 \index{NumPy}
 \index{Series}
 
-The outcome code {\tt 1} indicates a live birth. Code {\tt 4} indicates
+The outcome code \verb"1" indicates a live birth. Code \verb"4" indicates
 a miscarriage; that is, a pregnancy that ended spontaneously, usually
 with no known medical cause.
 
@@ -1359,19 +1359,19 @@ A solution to this exercise is in \verb"chap01soln.ipynb"
 \begin{exercise}
 In the repository you downloaded, you should find a file named
 \verb"chap01ex.py"; using this file as a starting place, write a
-function that reads the respondent file, {\tt 2002FemResp.dat.gz}.
+function that reads the respondent file, \verb"2002FemResp.dat.gz".
 
-The variable {\tt pregnum} is a recode that indicates how many
+The variable \verb"pregnum" is a recode that indicates how many
 times each respondent has been pregnant.  Print the value counts
 for this variable and compare them to the published results in
 the NSFG codebook.
 
 You can also cross-validate the respondent and pregnancy files by
-comparing {\tt pregnum} for each respondent with the number of
+comparing \verb"pregnum" for each respondent with the number of
 records in the pregnancy file.
 
-You can use {\tt nsfg.MakePregMap} to make a dictionary that maps
-from each {\tt caseid} to a list of indices into the pregnancy
+You can use \verb"nsfg.MakePregMap" to make a dictionary that maps
+from each \verb"caseid" to a list of indices into the pregnancy
 DataFrame.
 \index{DataFrame}
 
@@ -1495,7 +1495,7 @@ appears.  \index{histogram} \index{frequency}
 \index{dictionary}
 
 In Python, an efficient way to compute frequencies is with a
-dictionary.  Given a sequence of values, {\tt t}:
+dictionary.  Given a sequence of values, \verb"t":
 %
 \begin{verbatim}
 hist = {}
@@ -1504,15 +1504,15 @@ for x in t:
 \end{verbatim}
 
 The result is a dictionary that maps from values to frequencies.
-Alternatively, you could use the {\tt Counter} class defined in the
-{\tt collections} module:
+Alternatively, you could use the \verb"Counter" class defined in the
+\verb"collections" module:
 
 \begin{verbatim}
 from collections import Counter
 counter = Counter(t)
 \end{verbatim}
 
-The result is a {\tt Counter} object, which is a subclass of
+The result is a \verb"Counter" object, which is a subclass of
 dictionary.
 
 Another option is to use the pandas method \verb"value_counts", which
@@ -1536,7 +1536,7 @@ Series, or another Hist.  You can instantiate a Hist object like this:
 Hist({1: 1, 2: 2, 3: 1, 5: 1})
 \end{verbatim}
 
-Hist objects provide {\tt Freq}, which takes a value and
+Hist objects provide \verb"Freq", which takes a value and
 returns its frequency: \index{frequency}
 %
 \begin{verbatim}
@@ -1558,7 +1558,7 @@ If you look up a value that has never appeared, the frequency is 0.
 0
 \end{verbatim}
 
-{\tt Values} returns an unsorted list of the values in the Hist:
+\verb"Values" returns an unsorted list of the values in the Hist:
 %
 \begin{verbatim}
 >>> hist.Values()
@@ -1566,14 +1566,14 @@ If you look up a value that has never appeared, the frequency is 0.
 \end{verbatim}
 
 To loop through the values in order, you can use the built-in function
-{\tt sorted}:
+\verb"sorted":
 %
 \begin{verbatim}
 for val in sorted(hist.Values()):
     print(val, hist.Freq(val))
 \end{verbatim}
 
-Or you can use {\tt Items} to iterate through
+Or you can use \verb"Items" to iterate through
 value-frequency pairs: \index{frequency}
 %
 \begin{verbatim}
@@ -1592,14 +1592,14 @@ for val, freq in hist.Items():
 \label{first_wgt_lb_hist}
 \end{figure}
 
-For this book I wrote a module called {\tt thinkplot.py} that provides
-functions for plotting Hists and other objects defined in {\tt
-  thinkstats2.py}.  It is based on {\tt pyplot}, which is part of the
-{\tt matplotlib} package.  See Section~\ref{code} for information
-about installing {\tt matplotlib}.  \index{thinkplot}
+For this book I wrote a module called \verb"thinkplot.py" that provides
+functions for plotting Hists and other objects defined in
+\verb"thinkstats2.py".  It is based on \verb"pyplot", which is part of the
+\verb"matplotlib" package.  See Section~\ref{code} for information
+about installing \verb"matplotlib".  \index{thinkplot}
 \index{matplotlib}
 
-To plot {\tt hist} with {\tt thinkplot}, try this:
+To plot \verb"hist" with \verb"thinkplot", try this:
 \index{Hist}
 
 \begin{verbatim}
@@ -1608,7 +1608,7 @@ To plot {\tt hist} with {\tt thinkplot}, try this:
 >>> thinkplot.Show(xlabel='value', ylabel='frequency')
 \end{verbatim}
 
-You can read the documentation for {\tt thinkplot} at
+You can read the documentation for \verb"thinkplot" at
 \url{http://greenteapress.com/thinkstats2/thinkplot.html}.
 
 
@@ -1623,7 +1623,7 @@ You can read the documentation for {\tt thinkplot} at
 \section{NSFG variables}
 
 Now let's get back to the data from the NSFG.  The code in this
-chapter is in {\tt first.py}.  
+chapter is in \verb"first.py".  
 For information about downloading and
 working with this code, see Section~\ref{code}.
 
@@ -1632,7 +1632,7 @@ the variables you are planning to use one at a time, and a good
 way to start is by looking at histograms.
 \index{histogram}
 
-In Section~\ref{cleaning} we transformed {\tt agepreg}
+In Section~\ref{cleaning} we transformed \verb"agepreg"
 from centiyears to years, and combined \verb"birthwgt_lb" and
 \verb"birthwgt_oz" into a single quantity, \verb"totalwgt_lb".
 In this section I use these variables to demonstrate some
@@ -1670,7 +1670,7 @@ Next I generate and plot the histogram of
 \end{verbatim}
 
 When the argument passed to Hist is a pandas Series, any
-{\tt nan} values are dropped.  {\tt label} is a string that appears
+\verb"nan" values are dropped.  \verb"label" is a string that appears
 in the legend when the Hist is plotted.
 \index{pandas}
 \index{Series}
@@ -1728,8 +1728,8 @@ measurement and recording, or might be accurate reports of rare
 events.
 \index{outlier}
 
-Hist provides methods {\tt Largest} and {\tt Smallest}, which take
-an integer {\tt n} and return the {\tt n} largest or smallest
+Hist provides methods \verb"Largest" and \verb"Smallest", which take
+an integer \verb"n" and return the \verb"n" largest or smallest
 values from the histogram:
 \index{Hist}
 
@@ -1739,7 +1739,7 @@ values from the histogram:
 \end{verbatim}
 
 In the list of pregnancy lengths for live births, the 10 lowest values
-are {\tt [0, 4, 9, 13, 17, 18, 19, 20, 21, 22]}.  Values below 10 weeks
+are \verb"[0, 4, 9, 13, 17, 18, 19, 20, 21, 22]".  Values below 10 weeks
 are certainly errors; the most likely explanation is that the outcome
 was not coded correctly.  Values higher than 30 weeks are probably
 legitimate.  Between 10 and 30 weeks, it is hard to be sure; some
@@ -1778,7 +1778,7 @@ I will focus on pregnancies longer than 27 weeks.
 
 Now we can compare the distribution of pregnancy lengths for first
 babies and others.  I divided the DataFrame of live births using
-{\tt birthord}, and computed their histograms:
+\verb"birthord", and computed their histograms:
 \index{DataFrame}
 \index{Hist}
 \index{pregnancy length}
@@ -1802,7 +1802,7 @@ Then I plotted their histograms on the same axis:
                    xlim=[27, 46])
 \end{verbatim}
 
-{\tt thinkplot.PrePlot} takes the number of histograms
+\verb"thinkplot.PrePlot" takes the number of histograms
 we are planning to plot; it uses this information to choose
 an appropriate collection of colors.
 \index{thinkplot}
@@ -1814,13 +1814,13 @@ an appropriate collection of colors.
 \label{first_nsfg_hist}
 \end{figure}
 
-{\tt thinkplot.Hist} normally uses {\tt align='center'} so that
+\verb"thinkplot.Hist" normally uses \verb"align='center'" so that
 each bar is centered over its value.  For this figure, I use
-{\tt align='right'} and {\tt align='left'} to place
+\verb"align='right'" and \verb"align='left'" to place
 corresponding bars on either side of the value.
 \index{Hist}
 
-With {\tt width=0.45}, the total width of the two bars is 0.9,
+With \verb"width=0.45", the total width of the two bars is 0.9,
 leaving some space between each pair.
 
 Finally, I adjust the axis to show only data between 27 and 46 weeks.
@@ -1875,7 +1875,7 @@ Statistics designed to answer these questions are called {\bf summary
   mean}, which is meant to describe the central tendency of the
 distribution.  \index{mean} \index{average} \index{summary statistic}
 
-If you have a sample of {\tt n} values, $x_i$, the mean, $\xbar$, is
+If you have a sample of \verb"n" values, $x_i$, the mean, $\xbar$, is
 the sum of the values divided by the number of values; in other words
 %
 \[ \xbar = \frac{1}{n} \sum_i x_i \]
@@ -1930,7 +1930,7 @@ $S$, is the {\bf standard deviation}.  \index{deviation}
 \index{deviation}
 
 If you have prior experience, you might have seen a formula for
-variance with $n-1$ in the denominator, rather than {\tt n}.  This
+variance with $n-1$ in the denominator, rather than \verb"n".  This
 statistic is used to estimate the variance in a population using a
 sample.  We will come back to this in Chapter~\ref{estimation}.
 \index{sample variance}
@@ -2073,11 +2073,11 @@ My solution is in \verb"chap02soln.py".
 \begin{exercise}
 The mode of a distribution is the most frequent value; see
 \url{http://wikipedia.org/wiki/Mode_(statistics)}.  Write a function
-called {\tt Mode} that takes a Hist and returns the most
+called \verb"Mode" that takes a Hist and returns the most
 frequent value.\index{mode}
 \index{Hist}
 
-As a more challenging exercise, write a function called {\tt AllModes}
+As a more challenging exercise, write a function called \verb"AllModes"
 that returns a list of value-frequency pairs in descending order of
 frequency.
 \index{frequency}
@@ -2161,7 +2161,7 @@ that is relevant in practice.
 \chapter{Probability mass functions}
 \index{probability mass function}
 
-The code for this chapter is in {\tt probability.py}.
+The code for this chapter is in \verb"probability.py".
 For information about downloading and
 working with this code, see Section~\ref{code}.
 
@@ -2172,8 +2172,8 @@ working with this code, see Section~\ref{code}.
 Another way to represent a distribution is a {\bf probability mass
   function} (PMF), which maps from each value to its probability.  A
 {\bf probability} is a frequency expressed as a fraction of the sample
-size, {\tt n}.  To get from frequencies to probabilities, we divide
-through by {\tt n}, which is called {\bf normalization}.
+size, \verb"n".  To get from frequencies to probabilities, we divide
+through by \verb"n", which is called {\bf normalization}.
 \index{frequency}
 \index{probability}
 \index{normalization}
@@ -2190,7 +2190,7 @@ for x, freq in hist.Items():
     d[x] = freq / n
 \end{verbatim}
 %
-Or we can use the Pmf class provided by {\tt thinkstats2}.
+Or we can use the Pmf class provided by \verb"thinkstats2".
 Like Hist, the Pmf constructor can take a list, pandas
 Series, dictionary, Hist, or another Pmf object.  Here's an example
 with a simple list:
@@ -2206,12 +2206,12 @@ The Pmf is normalized so total probability is 1.
 
 Pmf and Hist objects are similar in many ways; in fact, they inherit
 many of their methods from a common parent class.  For example, the
-methods {\tt Values} and {\tt Items} work the same way for both.  The
+methods \verb"Values" and \verb"Items" work the same way for both.  The
 biggest difference is that a Hist maps from values to integer
 counters; a Pmf maps from values to floating-point probabilities.
 \index{Hist}
 
-To look up the probability associated with a value, use {\tt Prob}:
+To look up the probability associated with a value, use \verb"Prob":
 %
 \begin{verbatim}
 >>> pmf.Prob(2)
@@ -2244,15 +2244,15 @@ Or you can multiply a probability by a factor:
 \end{verbatim}
 
 If you modify a Pmf, the result may not be normalized; that is, the
-probabilities may no longer add up to 1.  To check, you can call {\tt
-  Total}, which returns the sum of the probabilities:
+probabilities may no longer add up to 1.  To check, you can call \verb"Total",
+which returns the sum of the probabilities:
 %
 \begin{verbatim}
 >>> pmf.Total()
 0.9
 \end{verbatim}
 
-To renormalize, call {\tt Normalize}:
+To renormalize, call \verb"Normalize":
 %
 \begin{verbatim}
 >>> pmf.Normalize()
@@ -2260,12 +2260,12 @@ To renormalize, call {\tt Normalize}:
 1.0
 \end{verbatim}
 
-Pmf objects provide a {\tt Copy} method so you can make
+Pmf objects provide a \verb"Copy" method so you can make
 and modify a copy without affecting the original.
 \index{Pmf}
 
 My notation in this section might seem inconsistent, but there is a
-system: I use Pmf for the name of the class, {\tt pmf} for an instance
+system: I use Pmf for the name of the class, \verb"pmf" for an instance
 of the class, and PMF for the mathematical concept of a
 probability mass function.
 
@@ -2273,19 +2273,19 @@ probability mass function.
 \section{Plotting PMFs}
 \index{PMF}
 
-{\tt thinkplot} provides two ways to plot Pmfs:
+\verb"thinkplot" provides two ways to plot Pmfs:
 \index{thinkplot}
 
 \begin{itemize}
 
 \item To plot a Pmf as a bar graph, you can use 
-{\tt thinkplot.Hist}.  Bar graphs are most useful if the number
+\verb"thinkplot.Hist".  Bar graphs are most useful if the number
 of values in the Pmf is small.
 \index{bar plot}
 \index{plot!bar}
 
 \item To plot a Pmf as a step function, you can use
-{\tt thinkplot.Pmf}.  This option is most useful if there are
+\verb"thinkplot.Pmf".  This option is most useful if there are
 a large number of values and the Pmf is smooth.  This function
 also works with Hist objects.
 \index{line plot}
@@ -2295,9 +2295,9 @@ also works with Hist objects.
 
 \end{itemize}
 
-In addition, {\tt pyplot} provides a function called {\tt hist} that
+In addition, \verb"pyplot" provides a function called \verb"hist" that
 takes a sequence of values, computes a histogram, and plots it.
-Since I use Hist objects, I usually don't use {\tt pyplot.hist}.
+Since I use Hist objects, I usually don't use \verb"pyplot.hist".
 \index{pyplot}
 
 \begin{figure}
@@ -2338,16 +2338,16 @@ Here's the code that generates Figure~\ref{probability_nsfg_pmf}:
                    axis=[27, 46, 0, 0.6])
 \end{verbatim}
 
-{\tt PrePlot} takes optional parameters {\tt rows} and {\tt cols}
+\verb"PrePlot" takes optional parameters \verb"rows" and \verb"cols"
 to make a grid of figures, in this case one row of two figures.
-The first figure (on the left) displays the Pmfs using {\tt thinkplot.Hist},
+The first figure (on the left) displays the Pmfs using \verb"thinkplot.Hist",
 as we have seen before.
 \index{thinkplot}
 \index{Hist}
 
-The second call to {\tt PrePlot} resets the color generator.  Then
-{\tt SubPlot} switches to the second figure (on the right) and
-displays the Pmfs using {\tt thinkplot.Pmfs}.  I used the {\tt axis} option
+The second call to \verb"PrePlot" resets the color generator.  Then
+\verb"SubPlot" switches to the second figure (on the right) and
+displays the Pmfs using \verb"thinkplot.Pmfs".  I used the \verb"axis" option
 to ensure that the two figures are on the same axes, which is
 generally a good idea if you intend to compare two figures.
 
@@ -2381,7 +2381,7 @@ graph, and to transform the data to emphasize differences:
     thinkplot.Bar(weeks, diffs)
 \end{verbatim}
 
-In this code, {\tt weeks} is the range of weeks; {\tt diffs} is the
+In this code, \verb"weeks" is the range of weeks; \verb"diffs" is the
 difference between the two PMFs in percentage points.
 Figure~\ref{probability_nsfg_diffs} shows the result as a bar chart.
 This figure makes the pattern clearer: first babies are less likely to
@@ -2480,8 +2480,8 @@ def BiasPmf(pmf, label):
     return new_pmf
 \end{verbatim}
 
-For each class size, {\tt x}, we multiply the probability by
-{\tt x}, the number of students who observe that class size.
+For each class size, \verb"x", we multiply the probability by
+\verb"x", the number of students who observe that class size.
 The result is a new Pmf that represents the biased distribution.
 
 Now we can plot the actual and observed distributions:
@@ -2527,8 +2527,8 @@ def UnbiasPmf(pmf, label):
     return new_pmf
 \end{verbatim}
 
-It's similar to {\tt BiasPmf}; the only difference is that it
-divides each probability by {\tt x} instead of multiplying.
+It's similar to \verb"BiasPmf"; the only difference is that it
+divides each probability by \verb"x" instead of multiplying.
 
 
 \section{DataFrame indexing}
@@ -2595,7 +2595,7 @@ d   -1.369968
 Name: A, dtype: float64
 \end{verbatim}
 
-To select a row by label, you can use the {\tt loc} attribute, which
+To select a row by label, you can use the \verb"loc" attribute, which
 returns a Series:
 
 \begin{verbatim}
@@ -2606,7 +2606,7 @@ Name: a, dtype: float64
 \end{verbatim}
 
 If you know the integer position of a row, rather than its label, you
-can use the {\tt iloc} attribute, which also returns a Series.
+can use the \verb"iloc" attribute, which also returns a Series.
 
 \begin{verbatim}
 >>> df.iloc[0]
@@ -2615,7 +2615,7 @@ B    0.61605
 Name: a, dtype: float64
 \end{verbatim}
 
-{\tt loc} can also take a list of labels; in that case,
+\verb"loc" can also take a list of labels; in that case,
 the result is a DataFrame.
 
 \begin{verbatim}
@@ -2695,10 +2695,10 @@ Similarly, you can compute variance like this:
 %
 \[ S^2 = \sum_i p_i~(x_i - \xbar)^2\]
 % 
-Write functions called {\tt PmfMean} and {\tt PmfVar} that take a
+Write functions called \verb"PmfMean" and \verb"PmfVar" that take a
 Pmf object and compute the mean and variance.  To test these methods,
-check that they are consistent with the methods {\tt Mean} and {\tt
-  Var} provided by Pmf.
+check that they are consistent with the methods \verb"Mean" and \verb"Var"
+provided by Pmf.
 \index{Pmf}
 
 \end{exercise}
@@ -2715,7 +2715,7 @@ To address this version of the question, select respondents who
 have at least two babies and compute pairwise differences.  Does
 this formulation of the question yield a different result?
 
-Hint: use {\tt nsfg.MakePregMap}.
+Hint: use \verb"nsfg.MakePregMap".
 \end{exercise}
 
 
@@ -2754,14 +2754,14 @@ the difference in our speeds.  I am more likely to catch a slow
 runner, and more likely to be caught by a fast runner.  But runners
 at the same speed are unlikely to see each other.
 
-Write a function called {\tt ObservedPmf} that takes a Pmf representing
+Write a function called \verb"ObservedPmf" that takes a Pmf representing
 the actual distribution of runners' speeds, and the speed of a running
 observer, and returns a new Pmf representing the distribution of
 runners' speeds as seen by the observer.
 \index{observer bias}
 \index{bias!observer}
 
-To test your function, you can use {\tt relay.py}, which  reads the
+To test your function, you can use \verb"relay.py", which  reads the
 results from the James Joyce Ramble 10K in Dedham MA and converts the
 pace of each runner to mph.
 
@@ -2800,7 +2800,7 @@ that contains the row labels.
 \chapter{Cumulative distribution functions}
 \label{cumulative}
 
-The code for this chapter is in {\tt cumulative.py}.
+The code for this chapter is in \verb"cumulative.py".
 For information about downloading and
 working with this code, see Section~\ref{code}.
 
@@ -2861,8 +2861,7 @@ percentile,'' you did as well as or better than 90\% of the people who
 took the exam.
 
 Here's how you could compute the percentile rank of a value,
-\verb"your_score", relative to the values in the sequence {\tt
-  scores}:
+\verb"your_score", relative to the values in the sequence \verb"scores":
 %
 \begin{verbatim}
 def PercentileRank(scores, your_score):
@@ -2877,7 +2876,7 @@ def PercentileRank(scores, your_score):
 
 As an example, if the
 scores in the sequence were 55, 66, 77, 88 and 99, and you got the 88,
-then your percentile rank would be {\tt 100 * 4 / 5} which is 80.
+then your percentile rank would be \verb"100 * 4 / 5" which is 80.
 
 If you are given a value, it is easy to find its percentile rank; going
 the other way is slightly harder.  If you are given a percentile rank
@@ -2897,7 +2896,7 @@ the 50th percentile is the value with percentile rank 50.  In the
 distribution of exam scores, the 50th percentile is 77.
 \index{percentile}
 
-This implementation of {\tt Percentile} is not efficient.  A
+This implementation of \verb"Percentile" is not efficient.  A
 better approach is to use the percentile rank to compute the index of
 the corresponding percentile:
 
@@ -2910,8 +2909,8 @@ def Percentile2(scores, percentile_rank):
 
 The difference between ``percentile'' and ``percentile rank'' can
 be confusing, and people do not always use the terms precisely.
-To summarize, {\tt PercentileRank} takes a value and computes
-its percentile rank in a set of values; {\tt Percentile} takes
+To summarize, \verb"PercentileRank" takes a value and computes
+its percentile rank in a set of values; \verb"Percentile" takes
 a percentile rank and computes the corresponding value.
 \index{percentile rank}
 
@@ -2932,7 +2931,7 @@ $x$, we compute the fraction of values in the distribution less
 than or equal to $x$.
 
 Here's what that looks like as a function that takes a sequence,
-{\tt sample}, and a value, {\tt x}:
+\verb"sample", and a value, \verb"x":
 %
 \begin{verbatim}
 def EvalCdf(sample, x):
@@ -2945,13 +2944,13 @@ def EvalCdf(sample, x):
     return prob
 \end{verbatim}
 
-This function is almost identical to {\tt PercentileRank}, except that
+This function is almost identical to \verb"PercentileRank", except that
 the result is a probability in the range 0--1 rather than a
 percentile rank in the range 0--100.
 \index{sample}
 
 As an example, suppose we collect a sample with the values 
-{\tt [1, 2, 2, 3, 5]}.  Here are some values from its CDF:
+\verb"[1, 2, 2, 3, 5]".  Here are some values from its CDF:
 %
 \[ CDF(0) = 0 \]
 %
@@ -2985,17 +2984,17 @@ The CDF of a sample is a step function.
 \section{Representing CDFs}
 \index{Cdf}
 
-{\tt thinkstats2} provides a class named Cdf that represents
+\verb"thinkstats2" provides a class named Cdf that represents
 CDFs.  The fundamental methods Cdf provides are:
 
 \begin{itemize}
 
-\item {\tt Prob(x)}: Given a value {\tt x}, computes the probability
-  $p = \CDF(x)$.  The bracket operator is equivalent to {\tt Prob}.
+\item \verb"Prob(x)": Given a value \verb"x", computes the probability
+  $p = \CDF(x)$.  The bracket operator is equivalent to \verb"Prob".
 \index{bracket operator}
 
-\item {\tt Value(p)}: Given a probability {\tt p}, computes the
-corresponding value, {\tt x}; that is, the {\bf inverse CDF} of {\tt p}.
+\item \verb"Value(p)": Given a probability \verb"p", computes the
+corresponding value, \verb"x"; that is, the {\bf inverse CDF} of \verb"p".
 \index{inverse CDF}
 \index{CDF, inverse}
 
@@ -3020,7 +3019,7 @@ the NSFG:
     cdf = thinkstats2.Cdf(live.prglngth, label='prglngth')
 \end{verbatim}
 
-{\tt thinkplot} provides a function named {\tt Cdf} that
+\verb"thinkplot" provides a function named \verb"Cdf" that
 plots Cdfs as lines:
 \index{thinkplot}
 
@@ -3100,23 +3099,23 @@ and percentile ranks.  The Cdf class provides these two methods:
 
 \begin{itemize}
 
-\item {\tt PercentileRank(x)}: Given a value {\tt x}, computes its
-  percentile rank, $100 \cdot \CDF(x)$.
+\item \verb"PercentileRank(x)": Given a value \verb"x", computes its
+percentile rank, $100 \cdot \CDF(x)$.
 
-\item {\tt Percentile(p)}: Given a percentile rank {\tt p},
-  computes the corresponding value, {\tt x}.  Equivalent to {\tt
-    Value(p/100)}.
+\item \verb"Percentile(p)": Given a percentile rank \verb"p",
+computes the corresponding value, \verb"x".  Equivalent to
+\verb"Value(p/100)".
 
 \end{itemize}
 
-{\tt Percentile} can be used to compute percentile-based summary
+\verb"Percentile" can be used to compute percentile-based summary
 statistics.  For example, the 50th percentile is the value that
 divides the distribution in half, also known as the {\bf median}.
 Like the mean, the median is a measure of the central tendency
 of a distribution.
 
 Actually, there are several definitions of ``median,'' each with
-different properties.  But {\tt Percentile(50)} is simple and
+different properties.  But \verb"Percentile(50)" is simple and
 efficient to compute.
 
 Another percentile-based statistic is the {\bf interquartile range} (IQR),
@@ -3165,9 +3164,9 @@ each value in the sample.
     ranks = [cdf.PercentileRank(x) for x in sample]
 \end{verbatim}
 
-{\tt sample}
+\verb"sample"
 is a random sample of 100 birth weights, chosen with {\bf replacement};
-that is, the same value could be chosen more than once.  {\tt ranks}
+that is, the same value could be chosen more than once.  \verb"ranks"
 is a list of percentile ranks.
 \index{replacement}
 
@@ -3207,14 +3206,14 @@ random numbers with a given CDF.  Here's how:
 
 \item Choose a percentile rank uniformly from the range 0--100.
 
-\item Use {\tt Cdf.Percentile} to find the value in the distribution
+\item Use \verb"Cdf.Percentile" to find the value in the distribution
 that corresponds to the percentile rank you chose.
 \index{Cdf}
 
 \end{itemize}
 
 Cdf provides an implementation of this algorithm, called
-{\tt Random}:
+\verb"Random":
 
 \begin{verbatim}
 # class Cdf:
@@ -3222,8 +3221,8 @@ Cdf provides an implementation of this algorithm, called
         return self.Percentile(random.uniform(0, 100))
 \end{verbatim}
 
-Cdf also provides {\tt Sample}, which takes an integer,
-{\tt n}, and returns a list of {\tt n} values chosen at random
+Cdf also provides \verb"Sample", which takes an integer,
+\verb"n", and returns a list of \verb"n" values chosen at random
 from the Cdf.
 
 
@@ -3295,11 +3294,11 @@ mother back and apologize.
 \end{exercise}
 
 \begin{exercise}
-The numbers generated by {\tt random.random} are supposed to be
+The numbers generated by \verb"random.random" are supposed to be
 uniform between 0 and 1; that is, every value in the range
 should have the same probability.
 
-Generate 1000 numbers from {\tt random.random} and plot their
+Generate 1000 numbers from \verb"random.random" and plot their
 PMF and CDF.  Is the distribution uniform?
 \index{uniform distribution}
 \index{distribution!uniform}
@@ -3369,7 +3368,7 @@ unneeded details.  This chapter presents common analytic distributions
 and uses them to model data from a variety of sources.
 \index{model}
 
-The code for this chapter is in {\tt analytic.py}.  For information
+The code for this chapter is in \verb"analytic.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
@@ -3409,8 +3408,8 @@ Australia.\footnote{This example is based on information and data from
   Dunn, ``A Simple Dataset for Demonstrating Common Distributions,''
   Journal of Statistics Education v.7, n.3 (1999).}  The time of
 birth for all 44 babies was reported in the local paper; the
-complete dataset is in a file called {\tt babyboom.dat}, in the
-{\tt ThinkStats2} repository.
+complete dataset is in a file called \verb"babyboom.dat", in the
+\verb"ThinkStats2" repository.
 \index{birth time}
 \index{Australia} \index{Brisbane}
 
@@ -3423,9 +3422,9 @@ complete dataset is in a file called {\tt babyboom.dat}, in the
     thinkplot.Show(xlabel='minutes', ylabel='CDF')
 \end{verbatim}
 
-{\tt ReadBabyBoom} reads the data file and returns a DataFrame
-with columns {\tt time}, {\tt sex}, \verb"weight_g", and {\tt minutes},
-where {\tt minutes} is time of birth converted to minutes since
+\verb"ReadBabyBoom" reads the data file and returns a DataFrame
+with columns \verb"time", \verb"sex", \verb"weight_g", and \verb"minutes",
+where \verb"minutes" is time of birth converted to minutes since
 midnight.
 \index{DataFrame}
 \index{thinkplot}
@@ -3444,8 +3443,8 @@ midnight.
 %\label{analytic_interarrival_ccdf}
 %\end{figure}
 
-{\tt diffs} is the difference between consecutive birth times, and
-{\tt cdf} is the distribution of these interarrival times.
+\verb"diffs" is the difference between consecutive birth times, and
+\verb"cdf" is the distribution of these interarrival times.
 Figure~\ref{analytic_interarrival_cdf} (left) shows the CDF.  It seems
 to have the general shape of an exponential distribution, but how can
 we tell?
@@ -3479,9 +3478,9 @@ with slope $-\lambda$.  Here's how we can generate a plot like that:
                    yscale='log')
 \end{verbatim}
 
-With the argument {\tt complement=True}, {\tt thinkplot.Cdf} computes
-the complementary CDF before plotting.  And with {\tt yscale='log'},
-{\tt thinkplot.Show} sets the {\tt y} axis to a logarithmic scale.
+With the argument \verb"complement=True", \verb"thinkplot.Cdf" computes
+the complementary CDF before plotting.  And with \verb"yscale='log'",
+\verb"thinkplot.Show" sets the \verb"y" axis to a logarithmic scale.
 \index{thinkplot}
 \index{Cdf}
 
@@ -3533,9 +3532,9 @@ $\mu$, and standard deviation $\sigma$.  The normal distribution with
 $\mu=0$ and $\sigma=1$ is called the {\bf standard normal
   distribution}.  Its CDF is defined by an integral that does not have
 a closed form solution, but there are algorithms that evaluate it
-efficiently.  One of them is provided by SciPy: {\tt scipy.stats.norm}
+efficiently.  One of them is provided by SciPy: \verb"scipy.stats.norm"
 is an object that represents a normal distribution; it provides a
-method, {\tt cdf}, that evaluates the standard normal CDF:
+method, \verb"cdf", that evaluates the standard normal CDF:
 \index{SciPy}
 \index{closed form}
 
@@ -3549,13 +3548,13 @@ This result is correct: the median of the standard normal distribution
 is 0 (the same as the mean), and half of the values fall below the
 median, so $\CDF(0)$ is 0.5.
 
-{\tt norm.cdf} takes optional parameters: {\tt loc}, which
-specifies the mean, and {\tt scale}, which specifies the
+\verb"norm.cdf" takes optional parameters: \verb"loc", which
+specifies the mean, and \verb"scale", which specifies the
 standard deviation.
 
-{\tt thinkstats2} makes this function a little easier to use
-by providing {\tt EvalNormalCdf}, which takes parameters {\tt mu}
-and {\tt sigma} and evaluates the CDF at {\tt x}:
+\verb"thinkstats2" makes this function a little easier to use
+by providing \verb"EvalNormalCdf", which takes parameters \verb"mu"
+and \verb"sigma" and evaluates the CDF at \verb"x":
 \index{normal distribution}
 
 \begin{verbatim}
@@ -3633,8 +3632,8 @@ generate a random sample with the same size as the sample, and sort it.
 \end{enumerate}
 
 If the distribution of the sample is approximately normal, the result
-is a straight line with intercept {\tt mu} and slope {\tt sigma}.
-{\tt thinkstats2} provides {\tt NormalProbability}, which takes a
+is a straight line with intercept \verb"mu" and slope \verb"sigma".
+\verb"thinkstats2" provides \verb"NormalProbability", which takes a
 sample and returns two NumPy arrays:
 \index{NumPy}
 
@@ -3649,10 +3648,10 @@ xs, ys = thinkstats2.NormalProbability(sample)
 \label{analytic_normal_prob_example}
 \end{figure}
 
-{\tt ys} contains the sorted values from {\tt sample}; {\tt xs}
+\verb"ys" contains the sorted values from \verb"sample"; \verb"xs"
 contains the random values from the standard normal distribution.
 
-To test {\tt NormalProbability} I generated some fake samples that
+To test \verb"NormalProbability" I generated some fake samples that
 were actually drawn from normal distributions with various parameters.
 Figure~\ref{analytic_normal_prob_example} shows the results.
 The lines are approximately straight, with values in the tails
@@ -3678,20 +3677,20 @@ def MakeNormalPlot(weights):
     thinkplot.Plot(xs, ys, label='birth weights')
 \end{verbatim}
 
-{\tt weights} is a pandas Series of birth weights;
-{\tt mean} and {\tt std} are the mean and standard deviation.
+\verb"weights" is a pandas Series of birth weights;
+\verb"mean" and \verb"std" are the mean and standard deviation.
 \index{pandas}
 \index{Series}
 \index{thinkplot}
 \index{standard deviation}
 
-{\tt FitLine} takes a sequence of {\tt xs}, an intercept, and a
-slope; it returns {\tt xs} and {\tt ys} that represent a line
-with the given parameters, evaluated at the values in {\tt xs}.
+\verb"FitLine" takes a sequence of \verb"xs", an intercept, and a
+slope; it returns \verb"xs" and \verb"ys" that represent a line
+with the given parameters, evaluated at the values in \verb"xs".
 
-{\tt NormalProbability} returns {\tt xs} and {\tt ys} that
+\verb"NormalProbability" returns \verb"xs" and \verb"ys" that
 contain values from the standard normal distribution and values
-from {\tt weights}.  If the distribution of weights is normal,
+from \verb"weights".  If the distribution of weights is normal,
 the data should match the model.
 \index{model}
 
@@ -3785,9 +3784,9 @@ Among the data they collected are the weights in kilograms of
 \index{Behavioral Risk Factor Surveillance System}
 \index{BRFSS}
 
-The repository for this book contains {\tt CDBRFS08.ASC.gz},
+The repository for this book contains \verb"CDBRFS08.ASC.gz",
 a fixed-width ASCII file that contains data from the BRFSS,
-and {\tt brfss.py}, which reads the file and analyzes the data.
+and \verb"brfss.py", which reads the file and analyzes the data.
 
 \begin{figure}
 % brfss.py
@@ -3880,7 +3879,7 @@ I downloaded their data from
 \url{http://www.census.gov/popest/data/cities/totals/2012/SUB-EST2012-3.html};
 it is in the repository for this book in a file named
 \verb"PEP_2012_PEPANNRES_with_ann.csv".  The repository also
-contains {\tt populations.py}, which reads the file and plots
+contains \verb"populations.py", which reads the file and plots
 the distribution of populations.
 
 Figure~\ref{populations_pareto} shows the CCDF of populations on a
@@ -3947,15 +3946,15 @@ def expovariate(lam):
     return x
 \end{verbatim}
 
-{\tt expovariate} takes {\tt lam} and returns a random value chosen
-from the exponential distribution with parameter {\tt lam}.
+\verb"expovariate" takes \verb"lam" and returns a random value chosen
+from the exponential distribution with parameter \verb"lam".
 
 Two notes about this implementation:
 I called the parameter \verb"lam" because \verb"lambda" is a Python
 keyword.  Also, since $\log 0$ is undefined, we have to
-be a little careful.  The implementation of {\tt random.random}
+be a little careful.  The implementation of \verb"random.random"
 can return 0 but not 1, so $1 - p$ can be 1 but not 0, so
-{\tt log(1-p)} is always defined.  \index{random module}
+\verb"log(1-p)" is always defined.  \index{random module}
 
 
 \section{Why model?}
@@ -4028,8 +4027,8 @@ women.
 
 In order to join Blue Man Group, you have to be male between 5'10''
 and 6'1'' (see \url{http://bluemancasting.com}).  What percentage of
-the U.S. male population is in this range?  Hint: use {\tt
-  scipy.stats.norm.cdf}.
+the U.S. male population is in this range?  Hint: use
+\verb"scipy.stats.norm.cdf".
 \index{SciPy}
 
 \end{exercise}
@@ -4073,7 +4072,7 @@ line indicate?
 \index{distribution!exponential}
 \index{random module}
 
-Use {\tt random.weibullvariate} to generate a sample from a
+Use \verb"random.weibullvariate" to generate a sample from a
 Weibull distribution and use it to test your transformation.
 
 \end{exercise}
@@ -4096,14 +4095,14 @@ values from an exponential distribution with the same mean as the
 data, about 33 minutes between births.
 
 Plot the distribution of the random values and compare it to the
-actual distribution.  You can use {\tt random.expovariate} 
+actual distribution.  You can use \verb"random.expovariate" 
 to generate the values.
 
 \end{exercise}
 
 \begin{exercise}
 In the repository for this book, you'll find a set of data files
-called {\tt mystery0.dat}, {\tt mystery1.dat}, and so on.  Each
+called \verb"mystery0.dat", \verb"mystery1.dat", and so on.  Each
 contains a sequence of random numbers generated from an analytic
 distribution.
 \index{random number}
@@ -4118,7 +4117,7 @@ $ python test_models.py mystery0.dat
 
 Based on these plots, you should be able to infer what kind of
 distribution generated each file.  If you are stumped, you can
-look in {\tt mystery.py}, which contains the code that generated
+look in \verb"mystery.py", which contains the code that generated
 the files.
 
 \end{exercise}
@@ -4139,10 +4138,10 @@ The Current Population Survey (CPS) is a joint effort of the Bureau
 of Labor Statistics and the Census Bureau to study income and related
 variables.  Data collected in 2013 is available from
 \url{http://www.census.gov/hhes/www/cpstables/032013/hhinc/toc.htm}.
-I downloaded {\tt hinc06.xls}, which is an Excel spreadsheet with
-information about household income, and converted it to {\tt hinc06.csv},
+I downloaded \verb"hinc06.xls", which is an Excel spreadsheet with
+information about household income, and converted it to \verb"hinc06.csv",
 a CSV file you will find in the repository for this book.  You
-will also find {\tt hinc.py}, which reads this file.
+will also find \verb"hinc.py", which reads this file.
 
 Extract the distribution of incomes from this dataset.  Are any of the
 analytic distributions in this chapter a good model of the data?  A
@@ -4202,7 +4201,7 @@ random values from a standard normal distribution.
 \index{CDF}
 \index{derivative}
 
-The code for this chapter is in {\tt density.py}.  For information
+The code for this chapter is in \verb"density.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
@@ -4231,37 +4230,37 @@ if the density is not constant, you have to integrate over volume.
 Similarly, {\bf probability density} measures probability per unit of $x$.
 In order to get a probability mass, you have to integrate over $x$.
 
-{\tt thinkstats2} provides a class called Pdf that represents
+\verb"thinkstats2" provides a class called Pdf that represents
 a probability density function.  Every Pdf object provides the
 following methods:
 
 \begin{itemize}
 
-\item {\tt Density}, which takes a value, {\tt x}, and returns the
-  density of the distribution at {\tt x}.
+\item \verb"Density", which takes a value, \verb"x", and returns the
+  density of the distribution at \verb"x".
 
-\item {\tt Render}, which evaluates the density at a discrete set of
-  values and returns a pair of sequences: the sorted values, {\tt xs},
-  and their probability densities, {\tt ds}.
+\item \verb"Render", which evaluates the density at a discrete set of
+  values and returns a pair of sequences: the sorted values, \verb"xs",
+  and their probability densities, \verb"ds".
 
-\item {\tt MakePmf}, which evaluates {\tt Density}
+\item \verb"MakePmf", which evaluates \verb"Density"
   at a discrete set of values and returns a normalized Pmf that
   approximates the Pdf.
 \index{Pmf}
 
-\item {\tt GetLinspace}, which returns the default set of points used 
-  by {\tt Render} and {\tt MakePmf}.
+\item \verb"GetLinspace", which returns the default set of points used 
+  by \verb"Render" and \verb"MakePmf".
 
 \end{itemize}  
 
 Pdf is an abstract parent class, which means you should not
 instantiate it; that is, you cannot create a Pdf object.  Instead, you
 should define a child class that inherits from Pdf and provides
-definitions of {\tt Density} and {\tt GetLinspace}.  Pdf provides
-{\tt Render} and {\tt MakePmf}.
+definitions of \verb"Density" and \verb"GetLinspace".  Pdf provides
+\verb"Render" and \verb"MakePmf".
 
-For example, {\tt thinkstats2} provides a class named {\tt
-  NormalPdf} that evaluates the normal density function.
+For example, \verb"thinkstats2" provides a class named \verb"NormalPdf" that
+evaluates the normal density function.
 
 \begin{verbatim}
 class NormalPdf(Pdf):
@@ -4279,10 +4278,10 @@ class NormalPdf(Pdf):
         return np.linspace(low, high, 101)
 \end{verbatim}
 
-The NormalPdf object contains the parameters {\tt mu} and
-{\tt sigma}.  {\tt Density} uses
-{\tt scipy.stats.norm}, which is an object that represents a normal
-distribution and provides {\tt cdf} and {\tt pdf}, among other
+The NormalPdf object contains the parameters \verb"mu" and
+\verb"sigma".  \verb"Density" uses
+\verb"scipy.stats.norm", which is an object that represents a normal
+distribution and provides \verb"cdf" and \verb"pdf", among other
 methods (see Section~\ref{normal}).
 \index{SciPy}
 
@@ -4309,23 +4308,23 @@ we plot the Pdf, we can see the shape of the distribution:
 >>> thinkplot.Show()
 \end{verbatim}
 
-{\tt thinkplot.Pdf} plots the Pdf as a smooth function,
-as contrasted with {\tt thinkplot.Pmf}, which renders a Pmf as a
+\verb"thinkplot.Pdf" plots the Pdf as a smooth function,
+as contrasted with \verb"thinkplot.Pmf", which renders a Pmf as a
 step function.  Figure~\ref{pdf_example} shows the result, as well
 as a PDF estimated from a sample, which we'll compute in the next
 section.
 \index{thinkplot}
 
-You can use {\tt MakePmf} to approximate the Pdf:
+You can use \verb"MakePmf" to approximate the Pdf:
 
 \begin{verbatim}
 >>> pmf = pdf.MakePmf()
 \end{verbatim}
 
 By default, the resulting Pmf contains 101 points equally spaced from
-{\tt mu - 3*sigma} to {\tt mu + 3*sigma}.  Optionally, {\tt MakePmf}
-and {\tt Render} can take keyword arguments {\tt low}, {\tt high},
-and {\tt n}.
+\verb"mu - 3*sigma" to \verb"mu + 3*sigma".  Optionally, \verb"MakePmf"
+and \verb"Render" can take keyword arguments \verb"low", \verb"high",
+and \verb"n".
 
 \begin{figure}
 % pdf_example.py
@@ -4345,8 +4344,8 @@ the data.  You can read details at
 \index{KDE}
 \index{kernel density estimation}
 
-{\tt scipy} provides an implementation of KDE and {\tt thinkstats2}
-provides a class called {\tt EstimatedPdf} that uses it:
+\verb"scipy" provides an implementation of KDE and \verb"thinkstats2"
+provides a class called \verb"EstimatedPdf" that uses it:
 \index{SciPy}
 \index{NumPy}
 
@@ -4362,10 +4361,10 @@ class EstimatedPdf(Pdf):
 
 \verb"__init__" takes a sample
 and computes a kernel density estimate.  The result is a
-\verb"gaussian_kde" object that provides an {\tt evaluate}
+\verb"gaussian_kde" object that provides an \verb"evaluate"
 method.
 
-{\tt Density} takes a value or sequence, calls
+\verb"Density" takes a value or sequence, calls
 \verb"gaussian_kde.evaluate", and returns the resulting density.  The
 word ``Gaussian'' appears in the name because it uses a filter based
 on a Gaussian distribution to smooth the KDE.  \index{density}
@@ -4481,7 +4480,7 @@ far as I can tell no one uses that term.  \index{CDF}
 \section{Hist implementation}
 
 At this point you should know how to use the basic types provided
-by {\tt thinkstats2}: Hist, Pmf, Cdf, and Pdf.  The next few sections
+by \verb"thinkstats2": Hist, Pmf, Cdf, and Pdf.  The next few sections
 provide details about how they are implemented.  This material
 might help you use these classes more effectively, but it is not
 strictly necessary.
@@ -4491,7 +4490,7 @@ Hist and Pmf inherit from a parent class called \verb"_DictWrapper".
 The leading underscore indicates that this class is ``internal;'' that
 is, it should not be used by code in other modules.  The name
 indicates what it is: a dictionary wrapper.  Its primary attribute is
-{\tt d}, the dictionary that maps from values to their frequencies.
+\verb"d", the dictionary that maps from values to their frequencies.
 \index{DictWrapper}
 \index{internal class}
 \index{wrapper}
@@ -4501,9 +4500,9 @@ but can be any numeric type.
 \index{hashable}
 
 \verb"_DictWrapper" contains methods appropriate for both
-Hist and Pmf, including \verb"__init__", {\tt Values},
-{\tt Items} and {\tt Render}.  It also provides modifier
-methods {\tt Set}, {\tt Incr}, {\tt Mult}, and {\tt Remove}.  These
+Hist and Pmf, including \verb"__init__", \verb"Values",
+\verb"Items" and \verb"Render".  It also provides modifier
+methods \verb"Set", \verb"Incr", \verb"Mult", and \verb"Remove".  These
 methods are all implemented with dictionary operations.  For example:
 \index{dictionary}
 
@@ -4520,7 +4519,7 @@ methods are all implemented with dictionary operations.  For example:
         del self.d[x]
 \end{verbatim}
 
-Hist also provides {\tt Freq}, which looks up the frequency
+Hist also provides \verb"Freq", which looks up the frequency
 of a given value.
 \index{frequency}
 
@@ -4537,7 +4536,7 @@ maps values to floating-point probabilities, rather than integer
 frequencies.  If the sum of the probabilities is 1, the Pmf is normalized.
 \index{Pmf}
 
-Pmf provides {\tt Normalize}, which computes the sum of the
+Pmf provides \verb"Normalize", which computes the sum of the
 probabilities and divides through by a factor:
 
 \begin{verbatim}
@@ -4555,13 +4554,12 @@ probabilities and divides through by a factor:
         return total
 \end{verbatim}
 
-{\tt fraction} determines the sum of the probabilities after
+\verb"fraction" determines the sum of the probabilities after
 normalizing; the default value is 1.  If the total probability is 0,
-the Pmf cannot be normalized, so {\tt Normalize} raises {\tt
-  ValueError}.
+the Pmf cannot be normalized, so \verb"Normalize" raises \verb"ValueError".
 
 Hist and Pmf have the same constructor.  It can take
-as an argument a {\tt dict}, Hist, Pmf or Cdf, a pandas
+as an argument a \verb"dict", Hist, Pmf or Cdf, a pandas
 Series, a list of (value, frequency) pairs, or a sequence of values.
 \index{Hist}
 
@@ -4603,15 +4601,15 @@ a Hist.  Then it uses the Hist to initialize the attributes:
         self.ps /= self.ps[-1]
 \end{verbatim}
 
-{\tt xs} is the sorted list of values; {\tt freqs} is the list
-of corresponding frequencies.  {\tt np.cumsum} computes
+\verb"xs" is the sorted list of values; \verb"freqs" is the list
+of corresponding frequencies.  \verb"np.cumsum" computes
 the cumulative sum of the frequencies.  Dividing through by the
 total frequency yields cumulative probabilities.
-For {\tt n} values, the time to construct the
+For \verb"n" values, the time to construct the
 Cdf is proportional to $n \log n$.
 \index{frequency}
 
-Here is the implementation of {\tt Prob}, which takes a value
+Here is the implementation of \verb"Prob", which takes a value
 and returns its cumulative probability: 
 
 \begin{verbatim}
@@ -4624,8 +4622,8 @@ and returns its cumulative probability:
         return p
 \end{verbatim}
 
-The {\tt bisect} module provides an implementation of binary search.
-And here is the implementation of {\tt Value}, which takes a
+The \verb"bisect" module provides an implementation of binary search.
+And here is the implementation of \verb"Value", which takes a
 cumulative probability and returns the corresponding value:
 
 \begin{verbatim}
@@ -4640,7 +4638,7 @@ cumulative probability and returns the corresponding value:
 
 Given a Cdf, we can compute the Pmf by computing differences between
 consecutive cumulative probabilities.  If you call the Cdf constructor
-and pass a Pmf, it computes differences by calling {\tt Cdf.Items}:
+and pass a Pmf, it computes differences by calling \verb"Cdf.Items":
 \index{Pmf}
 \index{Cdf}
 
@@ -4653,13 +4651,13 @@ and pass a Pmf, it computes differences by calling {\tt Cdf.Items}:
         return zip(self.xs, a-b)
 \end{verbatim}
 
-{\tt np.roll} shifts the elements of {\tt a} to the right, and ``rolls''
+\verb"np.roll" shifts the elements of \verb"a" to the right, and ``rolls''
 the last one back to the beginning.  We replace the first element of
-{\tt b} with 0 and then compute the difference {\tt a-b}.  The result
+\verb"b" with 0 and then compute the difference \verb"a-b".  The result
 is a NumPy array of probabilities.
 \index{NumPy}
 
-Cdf provides {\tt Shift} and {\tt Scale}, which modify the
+Cdf provides \verb"Shift" and \verb"Scale", which modify the
 values in the Cdf, but the probabilities should be treated as
 immutable.
 
@@ -4885,10 +4883,10 @@ The Current Population Survey (CPS) is a joint effort of the Bureau
 of Labor Statistics and the Census Bureau to study income and related
 variables.  Data collected in 2013 is available from
 \url{http://www.census.gov/hhes/www/cpstables/032013/hhinc/toc.htm}.
-I downloaded {\tt hinc06.xls}, which is an Excel spreadsheet with
-information about household income, and converted it to {\tt hinc06.csv},
+I downloaded \verb"hinc06.xls", which is an Excel spreadsheet with
+information about household income, and converted it to \verb"hinc06.csv",
 a CSV file you will find in the repository for this book.  You
-will also find {\tt hinc2.py}, which reads this file and transforms
+will also find \verb"hinc2.py", which reads this file and transforms
 the data.
 \index{Current Population Survey}
 \index{Bureau of Labor Statistics}
@@ -4902,21 +4900,21 @@ more.''
 
 To estimate mean and other statistics from these data, we have to
 make some assumptions about the lower and upper bounds, and how
-the values are distributed in each range.  {\tt hinc2.py} provides
-{\tt InterpolateSample}, which shows one way to model
-this data.  It takes a DataFrame with a column, {\tt income}, that
-contains the upper bound of each range, and {\tt freq}, which contains
+the values are distributed in each range.  \verb"hinc2.py" provides
+\verb"InterpolateSample", which shows one way to model
+this data.  It takes a DataFrame with a column, \verb"income", that
+contains the upper bound of each range, and \verb"freq", which contains
 the number of respondents in each frame.
 \index{DataFrame}
 \index{model}
 
 It also takes \verb"log_upper", which is an assumed upper bound
-on the highest range, expressed in {\tt log10} dollars.  
+on the highest range, expressed in \verb"log10" dollars.  
 The default value, \verb"log_upper=6.0" represents the assumption
 that the largest income among the respondents is
 $10^6$, or one million dollars.
 
-{\tt InterpolateSample} generates a pseudo-sample; that is, a sample
+\verb"InterpolateSample" generates a pseudo-sample; that is, a sample
 of household incomes that yields the same number of respondents
 in each range as the actual data.  It assumes that incomes in
 each range are equally spaced on a log10 scale.
@@ -4995,7 +4993,7 @@ know their height than if you don't.
 \index{adult weight}
 \index{adult height}
 
-The code for this chapter is in {\tt scatter.py}.
+The code for this chapter is in \verb"scatter.py".
 For information about downloading and
 working with this code, see Section~\ref{code}.
 
@@ -5019,7 +5017,7 @@ weight:
     heights, weights = sample.htm3, sample.wtkg2
 \end{verbatim}
 
-{\tt SampleRows} chooses a random subset of the data:
+\verb"SampleRows" chooses a random subset of the data:
 \index{SampleRows}
 
 \begin{verbatim}
@@ -5029,8 +5027,8 @@ def SampleRows(df, nrows, replace=False):
     return sample
 \end{verbatim}
 
-{\tt df} is the DataFrame, {\tt nrows} is the number of rows to choose,
-and {\tt replace} is a boolean indicating whether sampling should be
+\verb"df" is the DataFrame, \verb"nrows" is the number of rows to choose,
+and \verb"replace" is a boolean indicating whether sampling should be
 done with replacement; in other words, whether the same row could be
 chosen more than once.
 \index{DataFrame}
@@ -5038,7 +5036,7 @@ chosen more than once.
 \index{boolean}
 \index{replacement}
 
-{\tt thinkplot} provides {\tt Scatter}, which makes scatter plots:
+\verb"thinkplot" provides \verb"Scatter", which makes scatter plots:
 %
 \begin{verbatim}
     thinkplot.Scatter(heights, weights)
@@ -5080,7 +5078,7 @@ were rounded to the nearest inch, they might be off by up to 0.5 inches or
     weights = thinkstats2.Jitter(weights, 0.5)
 \end{verbatim}
 
-Here's the implementation of {\tt Jitter}:
+Here's the implementation of \verb"Jitter":
 
 \begin{verbatim}
 def Jitter(values, jitter=0.5):
@@ -5111,7 +5109,7 @@ hexbin plot (right).}
 \label{scatter2}
 \end{figure}
 
-We can solve this problem with the {\tt alpha} parameter, which makes
+We can solve this problem with the \verb"alpha" parameter, which makes
 the points partly transparent:
 %
 \begin{verbatim}
@@ -5137,8 +5135,8 @@ of 414 509.
 
 To handle larger datasets, another option is a hexbin plot, which
 divides the graph into hexagonal bins and colors each bin according to
-how many data points fall in it.  {\tt thinkplot} provides 
-{\tt HexBin}:
+how many data points fall in it.  \verb"thinkplot" provides 
+\verb"HexBin":
 %
 \begin{verbatim}
     thinkplot.HexBin(heights, weights)
@@ -5177,17 +5175,17 @@ NumPy and pandas provide functions for binning data:
     groups = df.groupby(indices)
 \end{verbatim}
 
-{\tt dropna} drops rows with {\tt nan} in any of the listed columns.
-{\tt arange} makes a NumPy array of bins from 135 to, but not including,
+\verb"dropna" drops rows with \verb"nan" in any of the listed columns.
+\verb"arange" makes a NumPy array of bins from 135 to, but not including,
 210, in increments of 5.
 \index{dropna}
 \index{digitize}
 \index{NaN}
 
-{\tt digitize} computes the index of the bin that contains each value
-in {\tt df.htm3}.  The result is a NumPy array of integer indices.
+\verb"digitize" computes the index of the bin that contains each value
+in \verb"df.htm3".  The result is a NumPy array of integer indices.
 Values that fall below the lowest bin are mapped to index 0.  Values
-above the highest bin are mapped to {\tt len(bins)}.
+above the highest bin are mapped to \verb"len(bins)".
 
 \begin{figure}
 % scatter.py
@@ -5196,8 +5194,8 @@ above the highest bin are mapped to {\tt len(bins)}.
 \label{scatter3}
 \end{figure}
 
-{\tt groupby} is a DataFrame method that returns a GroupBy object;
-used in a {\tt for} loop, {\tt groups} iterates the names of the groups
+\verb"groupby" is a DataFrame method that returns a GroupBy object;
+used in a \verb"for" loop, \verb"groups" iterates the names of the groups
 and the DataFrames that represent them.  So, for example, we can
 print the number of rows in each group like this:
 \index{DataFrame}
@@ -5323,11 +5321,11 @@ where $n$ is the length of the two series (they have to be the same
 length).
 
 If you have studied linear algebra, you might recognize that
-{\tt Cov} is the dot product of the deviations, divided
+\verb"Cov" is the dot product of the deviations, divided
 by their length.  So the covariance is maximized if the two vectors
 are identical, 0 if they are orthogonal, and negative if they
-point in opposite directions.  {\tt thinkstats2} uses {\tt np.dot} to
-implement {\tt Cov} efficiently:
+point in opposite directions.  \verb"thinkstats2" uses \verb"np.dot" to
+implement \verb"Cov" efficiently:
 \index{linear algebra}
 \index{dot product}
 \index{orthogonal vector}
@@ -5346,16 +5344,16 @@ def Cov(xs, ys, meanx=None, meany=None):
     return cov
 \end{verbatim}
 
-By default {\tt Cov} computes deviations from the sample means,
-or you can provide known means.  If {\tt xs} and {\tt ys} are
-Python sequences, {\tt np.asarray} converts them to NumPy arrays.
-If they are already NumPy arrays, {\tt np.asarray} does nothing.
+By default \verb"Cov" computes deviations from the sample means,
+or you can provide known means.  If \verb"xs" and \verb"ys" are
+Python sequences, \verb"np.asarray" converts them to NumPy arrays.
+If they are already NumPy arrays, \verb"np.asarray" does nothing.
 \index{NumPy}
 
 This implementation of covariance is meant to be simple for purposes
 of explanation.  NumPy and pandas also provide implementations of
 covariance, but both of them apply a correction for small sample sizes
-that we have not covered yet, and {\tt np.cov} returns a covariance
+that we have not covered yet, and \verb"np.cov" returns a covariance
 matrix, which is more than we need for now.
 \index{pandas}
 
@@ -5394,7 +5392,7 @@ interpret.  Because standard scores are dimensionless, so is $\rho$.
 \index{Pearson, Karl}
 \index{Pearson coefficient of correlation}
 
-Here is the implementation in {\tt thinkstats2}:
+Here is the implementation in \verb"thinkstats2":
 
 \begin{verbatim}
 def Corr(xs, ys):
@@ -5408,8 +5406,8 @@ def Corr(xs, ys):
     return corr
 \end{verbatim}
 
-{\tt MeanVar} computes mean and variance slightly more efficiently
-than separate calls to {\tt np.mean} and {\tt np.var}.
+\verb"MeanVar" computes mean and variance slightly more efficiently
+than separate calls to \verb"np.mean" and \verb"np.var".
 \index{MeanVar}
 
 Pearson's correlation is always between -1 and +1 (including both).
@@ -5480,14 +5478,14 @@ robust in the presence of outliers.
 Spearman's rank correlation is an alternative that mitigates the
 effect of outliers and skewed distributions.  To compute Spearman's
 correlation, we have to compute the {\bf rank} of each value, which is its
-index in the sorted sample.  For example, in the sample {\tt [1, 2, 5, 7]}
+index in the sorted sample.  For example, in the sample \verb"[1, 2, 5, 7]"
 the rank of the value 5 is 3, because it appears third in the sorted
 list.  Then we compute Pearson's correlation for the ranks.
 \index{skewness}
 \index{outlier}
 \index{rank}
 
-{\tt thinkstats2} provides a function that computes Spearman's rank
+\verb"thinkstats2" provides a function that computes Spearman's rank
 correlation:
 
 \begin{verbatim}
@@ -5498,13 +5496,13 @@ def SpearmanCorr(xs, ys):
 \end{verbatim}
 
 I convert the arguments to pandas Series objects so I can use
-{\tt rank}, which computes the rank for each value and returns
-a Series.  Then I use {\tt Corr} to compute the correlation
+\verb"rank", which computes the rank for each value and returns
+a Series.  Then I use \verb"Corr" to compute the correlation
 of the ranks.
 \index{pandas}
 \index{Series}
 
-I could also use {\tt Series.corr} directly and specify
+I could also use \verb"Series.corr" directly and specify
 Spearman's method:
 
 \begin{verbatim}
@@ -5709,7 +5707,7 @@ approximately random.
 \label{estimation}
 \index{estimation}
 
-The code for this chapter is in {\tt estimation.py}.  For information
+The code for this chapter is in \verb"estimation.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
@@ -5723,7 +5721,7 @@ normal distribution, and here's a random sample drawn from it:
 \index{Gaussian distribution}
 \index{distribution!Gaussian}
 
-{\tt [-0.441, 1.774, -0.101, -1.138, 2.975, -2.138]}
+\verb"[-0.441, 1.774, -0.101, -1.138, 2.975, -2.138]"
 
 What do you think is the mean parameter, $\mu$, of this distribution?
 \index{mean}
@@ -5749,7 +5747,7 @@ here's a sample that was collected by an unreliable surveyor who
 occasionally puts the decimal point in the wrong place.
 \index{measurement error}
 
-{\tt [-0.441, 1.774, -0.101, -1.138, 2.975, -213.8]}
+\verb"[-0.441, 1.774, -0.101, -1.138, 2.975, -213.8]"
 
 Now what's your estimate of $\mu$?  If you use the sample mean, your
 guess is -35.12.  Is that the best choice?  What are the alternatives?
@@ -5802,9 +5800,9 @@ def Estimate1(n=7, m=1000):
     print('rmse median', RMSE(medians, mu))
 \end{verbatim}
 
-Again, {\tt n} is the size of the sample, and {\tt m} is the
-number of times we play the game.  {\tt means} is the list of
-estimates based on $\xbar$.  {\tt medians} is the list of medians.
+Again, \verb"n" is the size of the sample, and \verb"m" is the
+number of times we play the game.  \verb"means" is the list of
+estimates based on $\xbar$.  \verb"medians" is the list of medians.
 \index{median}
 
 Here's the function that computes RMSE:
@@ -5816,9 +5814,9 @@ def RMSE(estimates, actual):
     return math.sqrt(mse)
 \end{verbatim}
 
-{\tt estimates} is a list of estimates; {\tt actual} is the
+\verb"estimates" is a list of estimates; \verb"actual" is the
 actual value being estimated.  In practice, of course, we don't
-know {\tt actual}; if we did, we wouldn't have to estimate it.
+know \verb"actual"; if we did, we wouldn't have to estimate it.
 The purpose of this experiment is to compare the performance of
 the two estimators.
 \index{estimator}
@@ -5862,7 +5860,7 @@ in 8, and that's the best you can do.  \index{MLE}
 {\em I'm thinking of a distribution\/.}  It's a normal distribution, and 
 here's a (familiar) sample:
 
-{\tt [-0.441, 1.774, -0.101, -1.138, 2.975, -2.138]}
+\verb"[-0.441, 1.774, -0.101, -1.138, 2.975, -2.138]"
 
 What do you think is the variance, $\sigma^2$, of my distribution?
 Again, the obvious choice is to use the sample variance, $S^2$, as an
@@ -5916,15 +5914,15 @@ def Estimate2(n=7, m=1000):
     print('mean error unbiased', MeanError(estimates2, sigma**2))
 \end{verbatim}
 
-Again, {\tt n} is the sample size and {\tt m} is the number of times
-we play the game.  {\tt np.var} computes $S^2$ by default and
-$S_{n-1}^2$ if you provide the argument {\tt ddof=1}, which stands for
+Again, \verb"n" is the sample size and \verb"m" is the number of times
+we play the game.  \verb"np.var" computes $S^2$ by default and
+$S_{n-1}^2$ if you provide the argument \verb"ddof=1", which stands for
 ``delta degrees of freedom.''  I won't explain that term, but you can read
 about it at
 \url{http://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)}.
 \index{degrees of freedom}
 
-{\tt MeanError} computes the mean difference between the estimates
+\verb"MeanError" computes the mean difference between the estimates
 and the actual value:
 
 \begin{verbatim}
@@ -5935,7 +5933,7 @@ def MeanError(estimates, actual):
 
 When I ran this code, the mean error for $S^2$ was -0.13.  As
 expected, this biased estimator tends to be too low.  For $S_{n-1}^2$,
-the mean error was 0.014, about 10 times smaller.  As {\tt m}
+the mean error was 0.014, about 10 times smaller.  As \verb"m"
 increases, we expect the mean error for $S_{n-1}^2$ to approach 0.
 \index{mean error}
 
@@ -6019,9 +6017,9 @@ def SimulateSample(mu=90, sigma=7.5, n=9, m=1000):
     stderr = RMSE(means, mu)
 \end{verbatim}
 
-{\tt mu} and {\tt sigma} are the {\em hypothetical\/} values of
-the parameters.  {\tt n} is the sample size, the number of
-gorillas we measured.  {\tt m} is the number of times we run
+\verb"mu" and \verb"sigma" are the {\em hypothetical\/} values of
+the parameters.  \verb"n" is the sample size, the number of
+gorillas we measured.  \verb"m" is the number of times we run
 the simulation.
 \index{gorilla}
 \index{sample size}
@@ -6034,10 +6032,10 @@ the simulation.
 \label{estimation1}
 \end{figure}
 
-In each iteration, we choose {\tt n} values from a normal
+In each iteration, we choose \verb"n" values from a normal
 distribution with the given parameters, and compute the sample mean,
-{\tt xbar}.  We run 1000 simulations and then compute the
-distribution, {\tt cdf}, of the estimates.  The result is shown in
+\verb"xbar".  We run 1000 simulations and then compute the
+distribution, \verb"cdf", of the estimates.  The result is shown in
 Figure~\ref{estimation1}.  This distribution is called the {\bf
   sampling distribution} of the estimator.  It shows how much the
 estimates would vary if we ran the experiment over and over.
@@ -6170,7 +6168,7 @@ Let's play one more round of the estimation game.
 {\em I'm thinking of a distribution.\/}  It's an exponential distribution, and 
 here's a sample:
 
-{\tt [5.384, 4.493, 19.198, 2.790, 6.122, 12.844]}
+\verb"[5.384, 4.493, 19.198, 2.790, 6.122, 12.844]"
 
 What do you think is the parameter, $\lambda$, of this distribution?
 \index{parameter}
@@ -6239,7 +6237,7 @@ it seems better than $L_m$.
 
 Sadly, it seems that both estimators are biased.  For $L$ the mean
 error is 0.33; for $L_m$ it is 0.45.  And neither converges to 0
-as {\tt m} increases.
+as \verb"m" increases.
 \index{biased estimator}
 \index{estimator!biased}
 
@@ -6251,7 +6249,7 @@ estimator of $\lambda$.
 \section{Exercises}
 
 For the following exercises, you might want to start with a copy of
-{\tt estimation.py}.  Solutions are in \verb"chap08soln.py"
+\verb"estimation.py".  Solutions are in \verb"chap08soln.py"
 
 \begin{exercise}
 
@@ -6300,18 +6298,18 @@ between goals, so let's see how it works.
 \index{hockey}
 \index{soccer}
 
-Write a function that takes a goal-scoring rate, {\tt lam}, in goals
+Write a function that takes a goal-scoring rate, \verb"lam", in goals
 per game, and simulates a game by generating the time between goals
 until the total time exceeds 1 game, then returns the number of goals
 scored.
 
 Write another function that simulates many games, stores the
-estimates of {\tt lam}, then computes their mean error and RMSE.
+estimates of \verb"lam", then computes their mean error and RMSE.
 
 Is this way of making an estimate biased?  Plot the sampling
 distribution of the estimates and the 90\% confidence interval.  What
 is the standard error?  What happens to sampling error for increasing
-values of {\tt lam}?
+values of \verb"lam"?
 \index{estimator!biased}
 \index{biased estimator}
 \index{standard error}
@@ -6376,7 +6374,7 @@ other sources of error).
 \chapter{Hypothesis testing}
 \label{testing}
 
-The code for this chapter is in {\tt hypothesis.py}.  For information
+The code for this chapter is in \verb"hypothesis.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 \section{Classical hypothesis testing}
@@ -6464,7 +6462,7 @@ conclude that the null hypothesis is unlikely to be true.
 \label{hypotest}
 \index{mean!difference in}
 
-{\tt thinkstats2} provides {\tt HypothesisTest}, a
+\verb"thinkstats2" provides \verb"HypothesisTest", a
 class that represents the structure of a classical hypothesis
 test.  Here is the definition:
 \index{HypothesisTest}
@@ -6494,28 +6492,28 @@ class HypothesisTest(object):
         raise UnimplementedMethodException()
 \end{verbatim}
 
-{\tt HypothesisTest} is an abstract parent class that provides
+\verb"HypothesisTest" is an abstract parent class that provides
 complete definitions for some methods and place-keepers for others.
-Child classes based on {\tt HypothesisTest} inherit \verb"__init__"
-and {\tt PValue} and provide {\tt TestStatistic},
-{\tt RunModel}, and optionally {\tt MakeModel}.
+Child classes based on \verb"HypothesisTest" inherit \verb"__init__"
+and \verb"PValue" and provide \verb"TestStatistic",
+\verb"RunModel", and optionally \verb"MakeModel".
 \index{HypothesisTest}
 
 \verb"__init__" takes the data in whatever form is appropriate.  It
-calls {\tt MakeModel}, which builds a representation of the null
-hypothesis, then passes the data to {\tt TestStatistic}, which
+calls \verb"MakeModel", which builds a representation of the null
+hypothesis, then passes the data to \verb"TestStatistic", which
 computes the size of the effect in the sample.
 \index{test statistic}
 \index{null hypothesis}
 
-{\tt PValue} computes the probability of the apparent effect under
-the null hypothesis.  It takes as a parameter {\tt iters}, which is
+\verb"PValue" computes the probability of the apparent effect under
+the null hypothesis.  It takes as a parameter \verb"iters", which is
 the number of simulations to run.  The first line generates simulated
 data, computes test statistics, and stores them in
 \verb"test_stats".
 The result is
 the fraction of elements in \verb"test_stats" that
-exceed or equal the observed test statistic, {\tt self.actual}.
+exceed or equal the observed test statistic, \verb"self.actual".
 \index{simulation}
 
 As a simple example\footnote{Adapted from MacKay, {\it Information
@@ -6545,21 +6543,21 @@ class CoinTest(thinkstats2.HypothesisTest):
         return data
 \end{verbatim}
 
-The parameter, {\tt data}, is a pair of
+The parameter, \verb"data", is a pair of
 integers: the number of heads and tails.  The test statistic is
-the absolute difference between them, so {\tt self.actual}
+the absolute difference between them, so \verb"self.actual"
 is 30.
 \index{HypothesisTest}
 
-{\tt RunModel} simulates coin tosses assuming that the coin is
+\verb"RunModel" simulates coin tosses assuming that the coin is
 actually fair.  It generates a sample of 250 tosses, uses Hist
 to count the number of heads and tails, and returns a pair of
 integers.
 \index{Hist}
 \index{model}
 
-Now all we have to do is instantiate {\tt CoinTest} and call
-{\tt PValue}:
+Now all we have to do is instantiate \verb"CoinTest" and call
+\verb"PValue":
 
 \begin{verbatim}
     ct = CoinTest((140, 110))
@@ -6633,18 +6631,18 @@ class DiffMeansPermute(thinkstats2.HypothesisTest):
         return data
 \end{verbatim}
 
-{\tt data} is a pair of sequences, one for each
+\verb"data" is a pair of sequences, one for each
 group.  The test statistic is the absolute difference in the means.
 \index{HypothesisTest}
 
-{\tt MakeModel} records the sizes of the groups, {\tt n} and
-{\tt m}, and combines the groups into one NumPy
-array, {\tt self.pool}.
+\verb"MakeModel" records the sizes of the groups, \verb"n" and
+\verb"m", and combines the groups into one NumPy
+array, \verb"self.pool".
 \index{NumPy}
 
-{\tt RunModel} simulates the null hypothesis by shuffling the
-pooled values and splitting them into two groups with sizes {\tt n}
-and {\tt m}.  As always, the return value from {\tt RunModel} has
+\verb"RunModel" simulates the null hypothesis by shuffling the
+pooled values and splitting them into two groups with sizes \verb"n"
+and \verb"m".  As always, the return value from \verb"RunModel" has
 the same format as the observed data.
 \index{null hypothesis}
 \index{model}
@@ -6658,10 +6656,10 @@ To test the difference in pregnancy length, we run:
     pvalue = ht.PValue()
 \end{verbatim}
 
-{\tt MakeFrames} reads the NSFG data and returns DataFrames
+\verb"MakeFrames" reads the NSFG data and returns DataFrames
 representing all live births, first babies, and others.
 We extract pregnancy lengths as NumPy arrays, pass them as
-data to {\tt DiffMeansPermute}, and compute the p-value.  The
+data to \verb"DiffMeansPermute", and compute the p-value.  The
 result is about 0.17, which means that we expect to see a difference
 as big as the observed effect about 17\% of the time.  So
 this effect is not statistically significant.
@@ -6678,7 +6676,7 @@ hypothesis.}
 \label{hypothesis1}
 \end{figure}
 
-{\tt HypothesisTest} provides {\tt PlotCdf}, which plots the
+\verb"HypothesisTest" provides \verb"PlotCdf", which plots the
 distribution of the test statistic and a gray line indicating
 the observed effect size:
 \index{thinkplot}
@@ -6732,9 +6730,9 @@ class DiffMeansOneSided(DiffMeansPermute):
         return test_stat
 \end{verbatim}
 
-{\tt DiffMeansOneSided} inherits {\tt MakeModel} and {\tt RunModel}
-from {\tt DiffMeansPermute}; the only difference is that
-{\tt TestStatistic} does not take the absolute value of the
+\verb"DiffMeansOneSided" inherits \verb"MakeModel" and \verb"RunModel"
+from \verb"DiffMeansPermute"; the only difference is that
+\verb"TestStatistic" does not take the absolute value of the
 difference.  This kind of test is called {\bf one-sided} because
 it only counts one side of the distribution of differences.  The
 previous test, using both sides, is {\bf two-sided}.
@@ -6816,9 +6814,9 @@ class CorrelationPermute(thinkstats2.HypothesisTest):
         return xs, ys
 \end{verbatim}
 
-{\tt data} is a pair of sequences.  {\tt TestStatistic} computes the
-absolute value of Pearson's correlation.  {\tt RunModel} shuffles the
-{\tt xs} and returns simulated data.
+\verb"data" is a pair of sequences.  \verb"TestStatistic" computes the
+absolute value of Pearson's correlation.  \verb"RunModel" shuffles the
+\verb"xs" and returns simulated data.
 \index{HypothesisTest}
 \index{permutation}
 \index{Pearson coefficient of correlation}
@@ -6833,7 +6831,7 @@ Here's the code that reads the data and runs the test:
     pvalue = ht.PValue()
 \end{verbatim}
 
-I use {\tt dropna} with the {\tt subset} argument to drop rows
+I use \verb"dropna" with the \verb"subset" argument to drop rows
 that are missing either of the variables we need.
 \index{dropna}
 \index{NaN}
@@ -6890,7 +6888,7 @@ total absolute difference is 20.  How often would we see such a
 difference by chance?
 \index{deviation}
 
-Here's a version of {\tt HypothesisTest} that answers that question:
+Here's a version of \verb"HypothesisTest" that answers that question:
 \index{HypothesisTest}
 
 \begin{verbatim}
@@ -6913,13 +6911,13 @@ class DiceTest(thinkstats2.HypothesisTest):
 \end{verbatim}
 
 The data are represented as a list of frequencies: the observed
-values are {\tt [8, 9, 19, 5, 8, 11]}; the expected frequencies
+values are \verb"[8, 9, 19, 5, 8, 11]"; the expected frequencies
 are all 10.  The test statistic is the sum of the absolute differences.
 \index{frequency}
 
 The null hypothesis is that the die is fair, so we simulate that by
-drawing random samples from {\tt values}.  {\tt RunModel} uses {\tt
-  Hist} to compute and return the list of frequencies.
+drawing random samples from \verb"values".  \verb"RunModel" uses \verb"Hist" to
+compute and return the list of frequencies.
 \index{Hist}
 \index{null hypothesis}
 \index{model}
@@ -6963,7 +6961,7 @@ class DiceChiTest(DiceTest):
 \end{verbatim}
 
 Squaring the deviations (rather than taking absolute values) gives
-more weight to large deviations.  Dividing through by {\tt expected}
+more weight to large deviations.  Dividing through by \verb"expected"
 standardizes the deviations, although in this case it has no effect
 because the expected frequencies are all equal.
 \index{deviation}
@@ -7022,8 +7020,8 @@ class PregLengthTest(thinkstats2.HypothesisTest):
 
 The data are represented as two lists of pregnancy lengths.  The null
 hypothesis is that both samples are drawn from the same distribution.
-{\tt MakeModel} models that distribution by pooling the two
-samples using {\tt hstack}.  Then {\tt RunModel} generates
+\verb"MakeModel" models that distribution by pooling the two
+samples using \verb"hstack".  Then \verb"RunModel" generates
 simulated data by shuffling the pooled sample and splitting it
 into two parts.
 \index{null hypothesis}
@@ -7031,7 +7029,7 @@ into two parts.
 \index{hstack}
 \index{pregnancy length}
 
-{\tt MakeModel} also defines {\tt values}, which is the
+\verb"MakeModel" also defines \verb"values", which is the
 range of weeks we'll use, and \verb"expected_probs",
 which is the probability of each value in the pooled distribution.
 
@@ -7053,16 +7051,16 @@ Here's the code that computes the test statistic:
         return stat
 \end{verbatim}
 
-{\tt TestStatistic} computes the chi-squared statistic for
+\verb"TestStatistic" computes the chi-squared statistic for
 first babies and others, and adds them.
 \index{chi-squared statistic}
 
-{\tt ChiSquared} takes a sequence of pregnancy lengths, computes
-its histogram, and computes {\tt observed}, which is a list of
-frequencies corresponding to {\tt self.values}.
+\verb"ChiSquared" takes a sequence of pregnancy lengths, computes
+its histogram, and computes \verb"observed", which is a list of
+frequencies corresponding to \verb"self.values".
 To compute the list of expected frequencies, it multiplies the
 pre-computed probabilities, \verb"expected_probs", by the sample
-size.  It returns the chi-squared statistic, {\tt stat}.
+size.  It returns the chi-squared statistic, \verb"stat".
 
 For the NSFG data the total chi-squared statistic is 102, which
 doesn't mean much by itself.  But after 1000 iterations, the largest
@@ -7113,7 +7111,7 @@ threshold is 5\%, the false positive rate is 5\%.  Here's why:
 
 \item Each time we run an experiment, we get a test statistic, $t$,
   which is drawn from $CDF_T$.  Then we compute a p-value, which is
-  the probability that a random value from $CDF_T$ exceeds {\tt t},
+  the probability that a random value from $CDF_T$ exceeds \verb"t",
   so that's $1 - CDF_T(t)$.
 
 \item The p-value is less than 5\% if $CDF_T(t)$ is greater
@@ -7158,14 +7156,14 @@ def FalseNegRate(data, num_runs=100):
     return count / num_runs
 \end{verbatim}
 
-{\tt FalseNegRate} takes data in the form of two sequences, one for
+\verb"FalseNegRate" takes data in the form of two sequences, one for
 each group.  Each time through the loop, it simulates an experiment by
 drawing a random sample from each group and running a hypothesis test.
 Then it checks the result and counts the number of false negatives.
 \index{Resample}
 \index{permutation}
 
-{\tt Resample} takes a sequence and draws a sample with the same
+\verb"Resample" takes a sequence and draws a sample with the same
 length, with replacement:
 \index{replacement}
 
@@ -7243,8 +7241,8 @@ replicate the result with new data are considered confirmatory.
 As it happens, we have an opportunity to replicate the results in this
 chapter.  The first edition of this book is based on Cycle 6 of the
 NSFG, which was released in 2002.  In October 2011, the CDC released
-additional data based on interviews conducted from 2006--2010.  {\tt
-  nsfg2.py} contains code to read and clean this data.  In the new
+additional data based on interviews conducted from 2006--2010.  \verb"nsfg2.py"
+contains code to read and clean this data.  In the new
 dataset:
 \index{NSFG}
 
@@ -7287,7 +7285,7 @@ be positive even if the effect is real.
 \index{sample size}
 
 To investigate this behavior, run the tests in this chapter with
-different subsets of the NSFG data.  You can use {\tt thinkstats2.SampleRows}
+different subsets of the NSFG data.  You can use \verb"thinkstats2.SampleRows"
 to select a random subset of the rows in a DataFrame.
 \index{National Survey of Family Growth}
 \index{NSFG}
@@ -7317,8 +7315,8 @@ with replacement from the observed values, as in Section~\ref{power}.
 \index{resampling}
 \index{replacement}
 
-Write a class named {\tt DiffMeansResample} that inherits from
-{\tt DiffMeansPermute} and overrides {\tt RunModel} to implement
+Write a class named \verb"DiffMeansResample" that inherits from
+\verb"DiffMeansPermute" and overrides \verb"RunModel" to implement
 resampling, rather than permutation.
 \index{permutation}
 
@@ -7395,7 +7393,7 @@ is false.
 \chapter{Linear least squares}
 \label{linear}
 
-The code for this chapter is in {\tt linear.py}.  For information
+The code for this chapter is in \verb"linear.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
@@ -7411,11 +7409,11 @@ squared error (MSE) between the line and the data.
 \index{linear least squares}
 \index{model}
 
-Suppose we have a sequence of points, {\tt ys}, that we want to
-express as a function of another sequence {\tt xs}.  If there is a
-linear relationship between {\tt xs} and {\tt ys} with intercept {\tt
-  inter} and slope {\tt slope}, we expect each {\tt y[i]} to be
-{\tt inter + slope * x[i]}.  \index{residuals}
+Suppose we have a sequence of points, \verb"ys", that we want to
+express as a function of another sequence \verb"xs".  If there is a
+linear relationship between \verb"xs" and \verb"ys" with intercept \verb"inter"
+and slope \verb"slope", we expect each \verb"y[i]" to be
+\verb"inter + slope * x[i]".  \index{residuals}
 
 But unless the correlation is perfect, this prediction is only
 approximate.  The vertical deviation from the line, or {\bf residual},
@@ -7434,7 +7432,7 @@ might include diet, exercise, and body type.
 \index{intercept}
 \index{measurement error}
 
-If we get the parameters {\tt inter} and {\tt slope} wrong, the residuals
+If we get the parameters \verb"inter" and \verb"slope" wrong, the residuals
 get bigger, so it makes intuitive sense that the parameters we want
 are the ones that minimize the residuals.
 \index{parameter}
@@ -7442,7 +7440,7 @@ are the ones that minimize the residuals.
 We might try to minimize the absolute value of the
 residuals, or their squares, or their cubes; but the most common
 choice is to minimize the sum of squared residuals,
-{\tt sum(res**2)}.
+\verb"sum(res**2)".
 
 Why?  There are three good reasons and one less important one:
 
@@ -7455,14 +7453,14 @@ negative residuals the same, which is usually what we want.
 so much weight that the largest residual always dominates.
 
 \item If the residuals are uncorrelated and normally distributed with
-  mean 0 and constant (but unknown) variance, then the least squares
-  fit is also the maximum likelihood estimator of {\tt inter} and {\tt
-    slope}.  See
-  \url{https://en.wikipedia.org/wiki/Linear_regression}.  \index{MLE}
-  \index{maximum likelihood estimator}
+mean 0 and constant (but unknown) variance, then the least squares
+fit is also the maximum likelihood estimator of \verb"inter" and
+\verb"slope".  See
+\url{https://en.wikipedia.org/wiki/Linear_regression}.  \index{MLE}
+\index{maximum likelihood estimator}
 \index{correlation}
 
-\item The values of {\tt inter} and {\tt slope} that minimize
+\item The values of \verb"inter" and \verb"slope" that minimize
   the squared residuals can be computed efficiently.
 
 \end{itemize}
@@ -7474,10 +7472,10 @@ whether squared residuals are the right thing to minimize.
 \index{computational methods}
 \index{squared residuals}
 
-For example, if you are using {\tt xs} to predict values of {\tt ys},
+For example, if you are using \verb"xs" to predict values of \verb"ys",
 guessing too high might be better (or worse) than guessing too low.
 In that case you might want to compute some cost function for each
-residual, and minimize total cost, {\tt sum(cost(res))}.
+residual, and minimize total cost, \verb"sum(cost(res))".
 However, computing a least squares fit is quick, easy and often good
 enough.  
 \index{cost function}
@@ -7485,7 +7483,7 @@ enough.
 
 \section{Implementation}
 
-{\tt thinkstats2} provides simple functions that demonstrate
+\verb"thinkstats2" provides simple functions that demonstrate
 linear least squares:
 \index{LeastSquares}
 
@@ -7500,16 +7498,16 @@ def LeastSquares(xs, ys):
     return inter, slope
 \end{verbatim}
 
-{\tt LeastSquares} takes sequences
-{\tt xs} and {\tt ys} and returns the estimated parameters {\tt inter}
-and {\tt slope}.
+\verb"LeastSquares" takes sequences
+\verb"xs" and \verb"ys" and returns the estimated parameters \verb"inter"
+and \verb"slope".
 For details on how it works, see
 \url{http://wikipedia.org/wiki/Numerical_methods_for_linear_least_squares}.
 \index{parameter}
 
-{\tt thinkstats2} also provides {\tt FitLine}, which takes {\tt inter}
-and {\tt slope} and returns the fitted line for a sequence
-of {\tt xs}.
+\verb"thinkstats2" also provides \verb"FitLine", which takes \verb"inter"
+and \verb"slope" and returns the fitted line for a sequence
+of \verb"xs".
 \index{FitLine}
 
 \begin{verbatim}
@@ -7574,7 +7572,7 @@ fitted line seems like a good model of the relationship.
 \label{residuals}
 
 Another useful test is to plot the residuals.
-{\tt thinkstats2} provides a function that computes residuals:
+\verb"thinkstats2" provides a function that computes residuals:
 \index{residuals}
 
 \begin{verbatim}
@@ -7585,8 +7583,8 @@ def Residuals(xs, ys, inter, slope):
     return res
 \end{verbatim}
 
-{\tt Residuals} takes sequences {\tt xs} and {\tt ys} and
-estimated parameters {\tt inter} and {\tt slope}.  It returns
+\verb"Residuals" takes sequences \verb"xs" and \verb"ys" and
+estimated parameters \verb"inter" and \verb"slope".  It returns
 the differences between the actual values and the fitted line.
 
 \begin{figure}
@@ -7618,7 +7616,7 @@ is a simple model that is probably good enough for some purposes.
 \section{Estimation}
 \label{regest}
 
-The parameters {\tt slope} and {\tt inter} are estimates based on a
+The parameters \verb"slope" and \verb"inter" are estimates based on a
 sample; like other estimates, they are vulnerable to sampling bias,
 measurement error, and sampling error.  As discussed in
 Chapter~\ref{estimation}, sampling bias is caused by non-representative
@@ -7658,11 +7656,11 @@ def SamplingDistributions(live, iters=101):
     return inters, slopes
 \end{verbatim}
 
-{\tt SamplingDistributions} takes a DataFrame with one row per live
-birth, and {\tt iters}, the number of experiments to simulate.  It
-uses {\tt ResampleRows} to resample the observed pregnancies.  We've
-already seen {\tt SampleRows}, which chooses random rows from a
-DataFrame.  {\tt thinkstats2} also provides {\tt ResampleRows}, which
+\verb"SamplingDistributions" takes a DataFrame with one row per live
+birth, and \verb"iters", the number of experiments to simulate.  It
+uses \verb"ResampleRows" to resample the observed pregnancies.  We've
+already seen \verb"SampleRows", which chooses random rows from a
+DataFrame.  \verb"thinkstats2" also provides \verb"ResampleRows", which
 returns a sample the same size as the original:
 \index{DataFrame}
 \index{resampling}
@@ -7690,7 +7688,7 @@ def Summarize(estimates, actual=None):
     print('mean, SE, CI', mean, stderr, ci)
 \end{verbatim}
 
-{\tt Summarize} takes a sequence of estimates and the actual value.
+\verb"Summarize" takes a sequence of estimates and the actual value.
 It prints the mean of the estimates, the standard error and 
 a 90\% confidence interval.
 \index{standard error}
@@ -7725,16 +7723,16 @@ def PlotConfidenceIntervals(xs, inters, slopes,
     thinkplot.FillBetween(fxs, low, high, **options)
 \end{verbatim}
 
-{\tt xs} is the sequence of mother's age.  {\tt inters} and {\tt slopes}
-are the estimated parameters generated by {\tt SamplingDistributions}.
-{\tt percent} indicates which confidence interval to plot.
+\verb"xs" is the sequence of mother's age.  \verb"inters" and \verb"slopes"
+are the estimated parameters generated by \verb"SamplingDistributions".
+\verb"percent" indicates which confidence interval to plot.
 
-{\tt PlotConfidenceIntervals} generates a fitted line for each pair
-of {\tt inter} and {\tt slope} and stores the results in a sequence,
-\verb"fys_seq".  Then it uses {\tt PercentileRows} to select the
-upper and lower percentiles of {\tt y} for each value of {\tt x}.
+\verb"PlotConfidenceIntervals" generates a fitted line for each pair
+of \verb"inter" and \verb"slope" and stores the results in a sequence,
+\verb"fys_seq".  Then it uses \verb"PercentileRows" to select the
+upper and lower percentiles of \verb"y" for each value of \verb"x".
 For a 90\% confidence interval, it selects the 5th and 95th percentiles.
-{\tt FillBetween} draws a polygon that fills the space between two
+\verb"FillBetween" draws a polygon that fills the space between two
 lines.
 \index{thinkplot}
 \index{FillBetween}
@@ -7743,7 +7741,7 @@ lines.
 % linear.py
 \centerline{\includegraphics[height=2.5in]{figs/linear3.pdf}}
 \caption{50\% and 90\% confidence intervals showing variability in the
-  fitted line due to sampling error of {\tt inter} and {\tt slope}.}
+  fitted line due to sampling error of \texttt{inter} and \texttt{slope}.}
 \label{linear3}
 \end{figure}
 
@@ -7765,7 +7763,7 @@ of the residuals.
 \index{standard deviation}
 \index{model}
 
-If you use a linear model to make predictions, {\tt Std(res)}
+If you use a linear model to make predictions, \verb"Std(res)"
 is the root mean squared error (RMSE) of your predictions.  For
 example, if you use mother's age to guess birth weight, the RMSE of
 your guess would be 1.40 lbs.
@@ -7773,7 +7771,7 @@ your guess would be 1.40 lbs.
 \index{weight!birth}
 
 If you guess birth weight without knowing the mother's age, the RMSE
-of your guess is {\tt Std(ys)}, which is 1.41 lbs.  So in this
+of your guess is \verb"Std(ys)", which is 1.41 lbs.  So in this
 example, knowing a mother's age does not improve the predictions
 substantially.
 \index{prediction}
@@ -7789,8 +7787,8 @@ def CoefDetermination(ys, res):
     return 1 - Var(res) / Var(ys)
 \end{verbatim}
 
-{\tt Var(res)} is the MSE of your guesses using the model,
-{\tt Var(ys)} is the MSE without it.   So their ratio is the fraction
+\verb"Var(res)" is the MSE of your guesses using the model,
+\verb"Var(ys)" is the MSE without it.   So their ratio is the fraction
 of MSE that remains if you use the model, and $R^2$ is the fraction
 of MSE the model eliminates.
 \index{MSE}
@@ -7806,9 +7804,9 @@ For example, if $\rho$ is 0.8 or -0.8, $R^2 = 0.64$.
 
 Although $\rho$ and $R^2$ are often used to quantify the strength of a
 relationship, they are not easy to interpret in terms of predictive
-power.  In my opinion, {\tt Std(res)} is the best representation
+power.  In my opinion, \verb"Std(res)" is the best representation
 of the quality of prediction, especially if it is presented
-in relation to {\tt Std(ys)}.
+in relation to \verb"Std(ys)".
 \index{coefficient of determination}
 \index{r-squared}
 
@@ -7824,7 +7822,7 @@ $\rho=0.72$ between total SAT scores and IQ scores, which sounds like
 a strong correlation.  But $R^2 = \rho^2 = 0.52$, so SAT scores
 account for only 52\% of variance in IQ.
 
-IQ scores are normalized with {\tt Std(ys) = 15}, so
+IQ scores are normalized with \verb"Std(ys) = 15", so
 
 \begin{verbatim}
 >>> var_ys = 15**2
@@ -7901,7 +7899,7 @@ class SlopeTest(thinkstats2.HypothesisTest):
 \end{verbatim}
 
 The data are represented as sequences of ages and weights.  The
-test statistic is the slope estimated by {\tt LeastSquares}.
+test statistic is the slope estimated by \verb"LeastSquares".
 The model of the null hypothesis is represented by the mean weight
 of all babies and the deviations from the mean.  To
 generate simulated data, we permute the deviations and add them to
@@ -8003,10 +8001,9 @@ This survey design is useful for many purposes, but it means that we
 cannot use the sample to estimate values for the general
 population without accounting for the sampling process.
 
-For each respondent, the NSFG data includes a variable called {\tt
-  finalwgt}, which is the number of people in the general population
-the respondent represents.  This value is called a {\bf sampling
-  weight}, or just ``weight.''
+For each respondent, the NSFG data includes a variable called \verb"finalwgt",
+which is the number of people in the general population the respondent
+represents.  This value is called a {\bf sampling weight}, or just ``weight.''
 \index{sampling weight}
 \index{weight}
 \index{weighted resampling}
@@ -8030,12 +8027,12 @@ and without sampling weights.
 \index{sampling distribution}
 \index{oversampling}
 
-In Section~\ref{regest}, we saw {\tt ResampleRows}, which chooses
+In Section~\ref{regest}, we saw \verb"ResampleRows", which chooses
 rows from a DataFrame, giving each row the same probability.
 Now we need to do the same thing using probabilities
 proportional to sampling weights.
-{\tt ResampleRowsWeighted} takes a DataFrame, resamples rows according
-to the weights in {\tt finalwgt}, and returns a DataFrame containing
+\verb"ResampleRowsWeighted" takes a DataFrame, resamples rows according
+to the weights in \verb"finalwgt", and returns a DataFrame containing
 the resampled rows:
 \index{DataFrame}
 \index{resampling}
@@ -8049,12 +8046,12 @@ def ResampleRowsWeighted(df, column='finalwgt'):
     return sample
 \end{verbatim}
 
-{\tt weights} is a Series; converting it to a dictionary makes
-a map from the indices to the weights.  In {\tt cdf} the values
+\verb"weights" is a Series; converting it to a dictionary makes
+a map from the indices to the weights.  In \verb"cdf" the values
 are indices and the probabilities are proportional to the
 weights.
 
-{\tt indices} is a sequence of row indices; {\tt sample} is a
+\verb"indices" is a sequence of row indices; \verb"sample" is a
 DataFrame that contains the selected rows.  Since we sample with
 replacement, the same row might appear more than once.  \index{Cdf}
 \index{replacement}
@@ -8124,7 +8121,7 @@ someone's weight, how much would it help to know their height?
 
 Like the NSFG, the BRFSS oversamples some groups and provides
 a sampling weight for each respondent.  In the BRFSS data, the variable
-name for these weights is {\tt finalwt}.
+name for these weights is \verb"finalwt".
 Use resampling, with and without weights, to estimate the mean height
 of respondents in the BRFSS, the standard error of the mean, and a
 90\% confidence interval.  How much does correct weighting affect the
@@ -8213,21 +8210,21 @@ unknown factors.
 Given a sequence of values for $y$ and sequences for $x_1$ and $x_2$,
 we can find the parameters, $\beta_0$, $\beta_1$, and $\beta_2$, that
 minimize the sum of $\eps^2$.  This process is called
-{\bf ordinary least squares}.  The computation is similar to {\tt
-  thinkstats2.LeastSquare}, but generalized to deal with more than one
+{\bf ordinary least squares}.  The computation is similar to
+\verb"thinkstats2.LeastSquare", but generalized to deal with more than one
 explanatory variable.  You can find the details at
 \url{https://en.wikipedia.org/wiki/Ordinary_least_squares}
 \index{explanatory variable}
 \index{ordinary least squares}
 \index{parameter}
 
-The code for this chapter is in {\tt regression.py}.  For information
+The code for this chapter is in \verb"regression.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 \section{StatsModels}
 \label{statsmodels}
 
-In the previous chapter I presented {\tt thinkstats2.LeastSquares}, an
+In the previous chapter I presented \verb"thinkstats2.LeastSquares", an
 implementation of simple linear regression intended to be easy to
 read.  For multiple regression we'll switch to StatsModels, a Python
 package that provides several forms of regression and other
@@ -8249,27 +8246,27 @@ StatsModels:
     results = model.fit()
 \end{verbatim}
 
-{\tt statsmodels} provides two interfaces (APIs); the ``formula''
+\verb"statsmodels" provides two interfaces (APIs); the ``formula''
 API uses strings to identify the dependent and explanatory variables.
-It uses a syntax called {\tt patsy}; in this example, the \verb"~"
+It uses a syntax called \verb"patsy"; in this example, the \verb"~"
 operator separates the dependent variable on the left from the
 explanatory variables on the right.
 \index{explanatory variable}
 \index{dependent variable}
 \index{Patsy}
 
-{\tt smf.ols} takes the formula string and the DataFrame, {\tt live},
-and returns an OLS object that represents the model.  The name {\tt ols}
+\verb"smf.ols" takes the formula string and the DataFrame, \verb"live",
+and returns an OLS object that represents the model.  The name \verb"ols"
 stands for ``ordinary least squares.''
 \index{DataFrame}
 \index{model}
 \index{ordinary least squares}
 
-The {\tt fit} method fits the model to the data and returns a
+The \verb"fit" method fits the model to the data and returns a
 RegressionResults object that contains the results.
 \index{RegressionResults}
 
-The results are also available as attributes.  {\tt params}
+The results are also available as attributes.  \verb"params"
 is a Series that maps from variable names to their parameters, so we can
 get the intercept and slope like this:
 \index{Series}
@@ -8280,10 +8277,10 @@ get the intercept and slope like this:
 \end{verbatim}
 
 The estimated parameters are 6.83 and 0.0175, the same as
-from {\tt LeastSquares}.
+from \verb"LeastSquares".
 \index{parameter}
 
-{\tt pvalues} is a Series that maps from variable names to the associated
+\verb"pvalues" is a Series that maps from variable names to the associated
 p-values, so we can check whether the estimated slope is statistically
 significant:
 \index{p-value}
@@ -8293,24 +8290,24 @@ significant:
     slope_pvalue = results.pvalues['agepreg']
 \end{verbatim}
 
-The p-value associated with {\tt agepreg} is {\tt 5.7e-11}, which
+The p-value associated with \verb"agepreg" is \verb"5.7e-11", which
 is less than $0.001$, as expected.
 \index{age}
 
-{\tt results.rsquared} contains $R^2$, which is $0.0047$.  {\tt
-  results} also provides \verb"f_pvalue", which is the p-value
+\verb"results.rsquared" contains $R^2$, which is $0.0047$.  \verb"results" also
+provides \verb"f_pvalue", which is the p-value
 associated with the model as a whole, similar to testing whether $R^2$
 is statistically significant.
 \index{model}
 \index{coefficient of determination}
 \index{r-squared}
 
-And {\tt results} provides {\tt resid}, a sequence of residuals, and
-{\tt fittedvalues}, a sequence of fitted values corresponding to
-{\tt agepreg}.
+And \verb"results" provides \verb"resid", a sequence of residuals, and
+\verb"fittedvalues", a sequence of fitted values corresponding to
+\verb"agepreg".
 \index{residuals}
 
-The results object provides {\tt summary()}, which
+The results object provides \verb"summary()", which
 represents the results in a readable format.  
 
 \begin{verbatim}
@@ -8318,7 +8315,7 @@ represents the results in a readable format.
 \end{verbatim}
 
 But it prints a lot of information that is not relevant (yet), so
-I use a simpler function called {\tt SummarizeResults}.  Here are
+I use a simpler function called \verb"SummarizeResults".  Here are
 the results of this model:
 
 \begin{verbatim}
@@ -8329,9 +8326,9 @@ Std(ys) 1.408
 Std(res) 1.405
 \end{verbatim}
 
-{\tt Std(ys)} is the standard deviation of the dependent variable,
+\verb"Std(ys)" is the standard deviation of the dependent variable,
 which is the RMSE if you have to guess birth weights without the benefit of
-any explanatory variables.  {\tt Std(res)} is the standard deviation
+any explanatory variables.  \verb"Std(res)" is the standard deviation
 of the residuals, which is the RMSE if your guesses are informed
 by the mother's age.  As we have already seen, knowing the mother's
 age provides no substantial improvement to the predictions.
@@ -8410,9 +8407,9 @@ more systematically.
     results = smf.ols(formula, data=live).fit()
 \end{verbatim}
 
-The first line creates a new column named {\tt isfirst} that is
+The first line creates a new column named \verb"isfirst" that is
 True for first babies and false otherwise.  Then we fit a model
-using {\tt isfirst} as an explanatory variable.
+using \verb"isfirst" as an explanatory variable.
 \index{model}
 \index{explanatory variable}
 
@@ -8424,11 +8421,11 @@ isfirst[T.True]  -0.125  (2.55e-05)
 R^2 0.00196
 \end{verbatim}
 
-Because {\tt isfirst} is a boolean, {\tt ols} treats it as a
+Because \verb"isfirst" is a boolean, \verb"ols" treats it as a
 {\bf categorical variable}, which means that the values fall
 into categories, like True and False, and should not be treated
 as numbers.  The estimated parameter is the effect on birth
-weight when {\tt isfirst} is true, so the result,
+weight when \verb"isfirst" is true, so the result,
 -0.125 lbs, is the difference in
 birth weight between first babies and others.  
 \index{birth weight}
@@ -8439,12 +8436,12 @@ birth weight between first babies and others.
 The slope and the intercept are statistically significant,
 which means that they were unlikely to occur by chance, but the
 the $R^2$ value for this model is small, which means that
-{\tt isfirst} doesn't account for a substantial part of the
+\verb"isfirst" doesn't account for a substantial part of the
 variation in birth weight.
 \index{coefficient of determination}
 \index{r-squared}
 
-The results are similar with {\tt agepreg}:
+The results are similar with \verb"agepreg":
 
 \begin{verbatim}
 Intercept       6.83    (0)
@@ -8468,10 +8465,10 @@ agepreg          0.0154  (3.93e-08)
 R^2 0.005289
 \end{verbatim}
 
-In the combined model, the parameter for {\tt isfirst} is smaller
+In the combined model, the parameter for \verb"isfirst" is smaller
 by about half, which means that part of the apparent effect of
-{\tt isfirst} is actually accounted for by {\tt agepreg}.  And
-the p-value for {\tt isfirst} is about 2.5\%, which is on the
+\verb"isfirst" is actually accounted for by \verb"agepreg".  And
+the p-value for \verb"isfirst" is about 2.5\%, which is on the
 border of statistical significance.
 \index{p-value}
 \index{model}
@@ -8488,9 +8485,9 @@ than either alone (but not by much).
 \section{Nonlinear relationships}
 \label{nonlinear}
 
-Remembering that the contribution of {\tt agepreg} might be nonlinear,
+Remembering that the contribution of \verb"agepreg" might be nonlinear,
 we might consider adding a variable to capture more of this
-relationship.  One option is to create a column, {\tt agepreg2},
+relationship.  One option is to create a column, \verb"agepreg2",
 that contains the squares of the ages:
 \index{nonlinear}
 
@@ -8499,7 +8496,7 @@ that contains the squares of the ages:
     formula = 'totalwgt_lb ~ isfirst + agepreg + agepreg2'
 \end{verbatim}
 
-Now by estimating parameters for {\tt agepreg} and {\tt agepreg2},
+Now by estimating parameters for \verb"agepreg" and \verb"agepreg2",
 we are effectively fitting a parabola:
 
 \begin{verbatim}
@@ -8510,13 +8507,13 @@ agepreg2        -0.00185  (8.8e-06)
 R^2 0.007462
 \end{verbatim}
 
-The parameter of {\tt agepreg2} is negative, so the parabola
+The parameter of \verb"agepreg2" is negative, so the parabola
 curves downward, which is consistent with the shape of the lines
 in Figure~\ref{linear2}.
 \index{parabola}
 
-The quadratic model of {\tt agepreg} accounts for more of the
-variability in birth weight; the parameter for {\tt isfirst}
+The quadratic model of \verb"agepreg" accounts for more of the
+variability in birth weight; the parameter for \verb"isfirst"
 is smaller in this model, and no longer statistically significant.
 \index{birth weight}
 \index{weight!birth}
@@ -8524,7 +8521,7 @@ is smaller in this model, and no longer statistically significant.
 \index{model}
   \index{significant} \index{statistically significant}
 
-Using computed variables like {\tt agepreg2} is a common way to
+Using computed variables like \verb"agepreg2" is a common way to
 fit polynomials and other functions to data.  
 This process is still considered linear
 regression, because the dependent variable is a linear function of
@@ -8559,14 +8556,14 @@ indicate a p-value less that 0.001.
 We conclude that the apparent difference in birth weight
 is explained, at least in part, by the difference in mother's age.
 When we include mother's age in the model, the effect of
-{\tt isfirst} gets smaller, and the remaining effect might be
+\verb"isfirst" gets smaller, and the remaining effect might be
 due to chance.
 \index{age}
 
 In this example, mother's age acts as a {\bf control variable};
-including {\tt agepreg} in the model ``controls for'' the
+including \verb"agepreg" in the model ``controls for'' the
 difference in age between first-time mothers and others, making
-it possible to isolate the effect (if any) of {\tt isfirst}. 
+it possible to isolate the effect (if any) of \verb"isfirst". 
 \index{control variable}
 
 
@@ -8602,7 +8599,7 @@ why not try them all?
 Testing the variables in the pregnancy table is easy, but in order to
 use the variables in the respondent table, we have to match up each
 pregnancy with a respondent.  In theory we could iterate through the
-rows of the pregnancy table, use the {\tt caseid} to find the
+rows of the pregnancy table, use the \verb"caseid" to find the
 corresponding respondent, and copy the values from the
 correspondent table into the pregnancy table.  But that would be slow.
 \index{join}
@@ -8628,19 +8625,19 @@ due date.
 
 The next line reads the respondent file.  The result is a DataFrame
 with integer indices; in order to look up respondents efficiently,
-I replace {\tt resp.index} with {\tt resp.caseid}. 
+I replace \verb"resp.index" with \verb"resp.caseid". 
 
-The {\tt join} method is invoked on {\tt live}, which is considered
-the ``left'' table, and passed {\tt resp}, which is the ``right'' table.
-The keyword argument {\tt on} indicates the variable used to match up
+The \verb"join" method is invoked on \verb"live", which is considered
+the ``left'' table, and passed \verb"resp", which is the ``right'' table.
+The keyword argument \verb"on" indicates the variable used to match up
 rows from the two tables.
 
 In this example some column names appear in both tables,
-so we have to provide {\tt rsuffix}, which is a string that will be
+so we have to provide \verb"rsuffix", which is a string that will be
 appended to the names of overlapping columns from the right table.
-For example, both tables have a column named {\tt race} that encodes
+For example, both tables have a column named \verb"race" that encodes
 the race of the respondent.  The result of the join contains two
-columns named {\tt race} and \verb"race_r".
+columns named \verb"race" and \verb"race_r".
 \index{race}
 
 The pandas implementation is fast.  Joining the NSFG tables takes
@@ -8669,7 +8666,7 @@ Now we can start testing variables.
 \end{verbatim}
 
 For each variable we construct a model, compute $R^2$, and append
-the results to a list.  The models all include {\tt agepreg}, since
+the results to a list.  The models all include \verb"agepreg", since
 we already know that it has some predictive power.
 \index{model}
 \index{coefficient of determination}
@@ -8678,7 +8675,7 @@ we already know that it has some predictive power.
 I check that each explanatory variable has some variability; otherwise
 the results of the regression are unreliable.  I also check the number
 of observations for each model.  Variables that contain a large number
-of {\tt nan}s are not good candidates for prediction.
+of \verb"nan"s are not good candidates for prediction.
 \index{explanatory variable}
 \index{NaN}
 
@@ -8707,19 +8704,19 @@ weight to predict birth weight.
 \index{birth weight}
 \index{weight!birth}
 
-Similarly {\tt prglngth} has useful predictive power, but for the
+Similarly \verb"prglngth" has useful predictive power, but for the
 office pool we assume pregnancy length (and the related variables)
 are not known yet.
 \index{predictive power}
 \index{pregnancy length}
 
-The first useful predictive variable is {\tt babysex} which indicates
+The first useful predictive variable is \verb"babysex" which indicates
 whether the baby is male or female.  In the NSFG dataset, boys are
 about 0.3 lbs heavier.  So, assuming that the sex of the baby is
 known, we can use it for prediction.
 \index{sex}
 
-Next is {\tt race}, which indicates whether the respondent is white,
+Next is \verb"race", which indicates whether the respondent is white,
 black, or other.  As an explanatory variable, race can be problematic.
 In datasets like the NSFG, race is correlated with many other
 variables, including income and other socioeconomic factors.  In a
@@ -8729,13 +8726,13 @@ part, by other factors.
 \index{explanatory variable}
 \index{race}
 
-The next variable on the list is {\tt nbrnaliv}, which indicates
+The next variable on the list is \verb"nbrnaliv", which indicates
 whether the pregnancy yielded multiple births.  Twins and triplets
 tend to be smaller than other babies, so if we know whether our
 hypothetical co-worker is expecting twins, that would help.
 \index{multiple birth}
 
-Next on the list is {\tt paydu}, which indicates whether the
+Next on the list is \verb"paydu", which indicates whether the
 respondent owns her home.  It is one of several income-related
 variables that turn out to be predictive.  In datasets like the NSFG,
 income and wealth are correlated with just about everything.  In this
@@ -8747,10 +8744,10 @@ factors likely to affect birth weight.
 \index{wealth}
 
 Some of the other variables on the list are things that would not
-be known until later, like {\tt bfeedwks}, the number of weeks
+be known until later, like \verb"bfeedwks", the number of weeks
 the baby was breast fed.  We can't use these variables for prediction,
 but you might want to speculate on reasons
-{\tt bfeedwks} might be correlated with birth weight.
+\verb"bfeedwks" might be correlated with birth weight.
 
 Sometimes you start with a theory and use data to test it.  Other
 times you start with data and go looking for possible theories.
@@ -8773,20 +8770,20 @@ models and settled on this one:
 \end{verbatim}
 
 This formula uses some syntax we have not seen yet:
-{\tt C(race)} tells the formula parser (Patsy) to treat race as a
+\verb"C(race)" tells the formula parser (Patsy) to treat race as a
 categorical variable, even though it is encoded numerically.
 \index{Patsy}
 \index{categorical variable}
 
-The encoding for {\tt babysex} is 1 for male, 2 for female; writing
-{\tt babysex==1} converts it to boolean, True for male and false for
+The encoding for \verb"babysex" is 1 for male, 2 for female; writing
+\verb"babysex==1" converts it to boolean, True for male and false for
 female.
 \index{boolean}
 
-Similarly {\tt nbrnaliv>1} is True for multiple births and 
-{\tt paydu==1} is True for respondents who own their houses.
+Similarly \verb"nbrnaliv>1" is True for multiple births and 
+\verb"paydu==1" is True for respondents who own their houses.
 
-{\tt totincr} is encoded numerically from 1-14, with each increment
+\verb"totincr" is encoded numerically from 1-14, with each increment
 representing about \$5000 in annual income.  So we can treat these
 values as numerical, expressed in units of \$5000.
 \index{income}
@@ -8819,7 +8816,7 @@ People who own their homes have heavier babies by about 0.12 lbs,
 even when we control for income.  The parameter for mother's
 age is smaller than what we saw in Section~\ref{multiple}, which
 suggests that some of the other variables are correlated with
-age, probably including {\tt paydu} and {\tt totincr}.
+age, probably including \verb"paydu" and \verb"totincr".
 \index{income}
 
 All of these variables are statistically significant, some with
@@ -8986,11 +8983,11 @@ And convert from log odds to probabilities:
 [ 0.182  0.401  0.401  0.916 ]
 \end{verbatim}
 
-Notice that when \verb"log_o" is greater than 0, {\tt o}
-is greater than 1 and {\tt p} is greater than 0.5.
+Notice that when \verb"log_o" is greater than 0, \verb"o"
+is greater than 1 and \verb"p" is greater than 0.5.
 
-The likelihood of an outcome is {\tt p} when {\tt y==1} and {\tt 1-p}
-when {\tt y==0}.  For example, if we think the probability of a boy is
+The likelihood of an outcome is \verb"p" when \verb"y==1" and \verb"1-p"
+when \verb"y==0".  For example, if we think the probability of a boy is
 0.8 and the outcome is a boy, the likelihood is 0.8; if
 the outcome is a girl, the likelihood is 0.2.  We can compute that
 like this:
@@ -9001,14 +8998,14 @@ like this:
 [ 0.817  0.401  0.598  0.916 ]
 \end{verbatim}
 
-The overall likelihood of the data is the product of {\tt likes}:
+The overall likelihood of the data is the product of \verb"likes":
 
 \begin{verbatim}
 >>> like = np.prod(likes)
 0.18
 \end{verbatim}
 
-For these values of {\tt beta}, the likelihood of the data is 0.18.
+For these values of \verb"beta", the likelihood of the data is 0.18.
 The goal of logistic regression is to find parameters that maximize
 this likelihood.  To do that, most statistics packages use an
 iterative solver like Newton's method (see
@@ -9021,7 +9018,7 @@ iterative solver like Newton's method (see
 \label{implementation}
 
 StatsModels provides an implementation of logistic regression
-called {\tt logit}, named for the function that converts from
+called \verb"logit", named for the function that converts from
 probability to log odds.  To demonstrate its use, I'll look for
 variables that affect the sex ratio.
 \index{StatsModels}
@@ -9036,9 +9033,9 @@ Again, I load the NSFG data and select pregnancies longer than
     df = live[live.prglngth>30]
 \end{verbatim}
 
-{\tt logit} requires the dependent variable to be binary (rather than
-boolean), so I create a new column named {\tt boy}, using {\tt
-  astype(int)} to convert to binary integers:
+\verb"logit" requires the dependent variable to be binary (rather than
+boolean), so I create a new column named \verb"boy", using \verb"astype(int)"
+to convert to binary integers:
 \index{dependent variable}
 \index{boolean}
 \index{binary}
@@ -9062,10 +9059,10 @@ start with the mother's age:
     SummarizeResults(results)
 \end{verbatim}
 
-{\tt logit} takes the same arguments as {\tt ols}, a formula
+\verb"logit" takes the same arguments as \verb"ols", a formula
 in Patsy syntax and a DataFrame.  The result is a Logit object
 that represents the model.  It contains attributes called
-{\tt endog} and {\tt exog} that contain the {\bf endogenous
+\verb"endog" and \verb"exog" that contain the {\bf endogenous
 variable}, another name for the dependent variable,
 and the {\bf exogenous variables}, another name for the
 explanatory variables.  Since they are NumPy arrays, it is
@@ -9084,8 +9081,8 @@ sometimes convenient to convert them to DataFrames:
     exog = pandas.DataFrame(model.exog, columns=model.exog_names)
 \end{verbatim}
 
-The result of {\tt model.fit} is a BinaryResults object, which is
-similar to the RegressionResults object we got from {\tt ols}.
+The result of \verb"model.fit" is a BinaryResults object, which is
+similar to the RegressionResults object we got from \verb"ols".
 Here is a summary of the results:
 
 \begin{verbatim}
@@ -9094,7 +9091,7 @@ agepreg     0.00105   (0.783)
 R^2 6.144e-06
 \end{verbatim}
 
-The parameter of {\tt agepreg} is positive, which suggests that
+The parameter of \verb"agepreg" is positive, which suggests that
 older mothers are more likely to have boys, but the p-value is
 0.783, which means that the apparent effect could easily be due
 to chance.
@@ -9118,7 +9115,7 @@ believed to be associated with sex ratio:
 \end{verbatim}
 
 Along with mother's age, this model includes father's age at
-birth ({\tt hpagelb}), birth order ({\tt birthord}), and
+birth (\verb"hpagelb"), birth order (\verb"birthord"), and
 race as a categorical variable.  Here are the results:
 \index{categorical variable}
 
@@ -9158,7 +9155,7 @@ strategy is just the fraction of boys:
     baseline = actual.mean()
 \end{verbatim}
 
-Since {\tt actual} is encoded in binary integers, the mean is the
+Since \verb"actual" is encoded in binary integers, the mean is the
 fraction of boys, which is 0.507.
 
 Here's how we compute the accuracy of the model:
@@ -9169,8 +9166,8 @@ Here's how we compute the accuracy of the model:
     true_neg = (1 - predict) * (1 - actual)
 \end{verbatim}
 
-{\tt results.predict} returns a NumPy array of probabilities, which we
-round off to 0 or 1.  Multiplying by {\tt actual}
+\verb"results.predict" returns a NumPy array of probabilities, which we
+round off to 0 or 1.  Multiplying by \verb"actual"
 yields 1 if we predict a boy and get it right, 0 otherwise.  So,
 \verb"true_pos" indicates ``true positives''.
 \index{NumPy}
@@ -9200,7 +9197,7 @@ her husband is 39, and they are expecting their third child:
     y = results.predict(new)
 \end{verbatim}
 
-To invoke {\tt results.predict} for a new case, you have to construct
+To invoke \verb"results.predict" for a new case, you have to construct
 a DataFrame with a column for each variable in the model.  The result
 in this case is 0.52, so you should guess ``boy.''  But if the model
 improves your chances of winning, the difference is very small.
@@ -9250,9 +9247,9 @@ a substantial effect?
 \begin{exercise}
 If the quantity you want to predict is a count, you can use Poisson
 regression, which is implemented in StatsModels with a function called
-{\tt poisson}.  It works the same way as {\tt ols} and {\tt logit}.
+\verb"poisson".  It works the same way as \verb"ols" and \verb"logit".
 As an exercise, let's use it to predict how many children a woman
-has born; in the NSFG dataset, this variable is called {\tt numbabes}.
+has born; in the NSFG dataset, this variable is called \verb"numbabes".
 \index{StatsModels}
 \index{Poisson regression}
 
@@ -9265,10 +9262,10 @@ children would you predict she has born?
 \begin{exercise}
 If the quantity you want to predict is categorical, you can use
 multinomial logistic regression, which is implemented in StatsModels
-with a function called {\tt mnlogit}.  As an exercise, let's use it to
+with a function called \verb"mnlogit".  As an exercise, let's use it to
 guess whether a woman is married, cohabitating, widowed, divorced,
 separated, or never married; in the NSFG dataset, marital status is
-encoded in a variable called {\tt rmarital}.
+encoded in a variable called \verb"rmarital".
 \index{categorical variable}
 \index{marital status}
 
@@ -9387,7 +9384,7 @@ important and difficult public policy questions; our decisions should
 be informed by accurate data reported honestly.
 \index{ethics}
 
-The code for this chapter is in {\tt timeseries.py}.  For information
+The code for this chapter is in \verb"timeseries.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
@@ -9405,7 +9402,7 @@ pandas DataFrame:
 \end{verbatim}
 
 \verb"parse_dates" tells \verb"read_csv" to interpret values in column 5
-as dates and convert them to NumPy {\tt datetime64} objects.
+as dates and convert them to NumPy \verb"datetime64" objects.
 \index{NumPy}
 
 The DataFrame has a row for each reported transaction and 
@@ -9459,13 +9456,13 @@ def GroupByQualityAndDay(transactions):
     return dailies
 \end{verbatim}
 
-{\tt groupby} is a DataFrame method that returns a GroupBy object,
-{\tt groups}; used in a for loop, it iterates the names of the groups
-and the DataFrames that represent them.  Since the values of {\tt
-  quality} are {\tt low}, {\tt medium}, and {\tt high}, we get three
+\verb"groupby" is a DataFrame method that returns a GroupBy object,
+\verb"groups"; used in a for loop, it iterates the names of the groups
+and the DataFrames that represent them.  Since the values of \verb"quality" are
+\verb"low", \verb"medium", and \verb"high", we get three
 groups with those names.  \index{DataFrame} \index{groupby}
 
-The loop iterates through the groups and calls {\tt GroupByDay},
+The loop iterates through the groups and calls \verb"GroupByDay",
 which computes the daily average price and returns a new DataFrame:
 
 \begin{verbatim}
@@ -9481,37 +9478,37 @@ def GroupByDay(transactions, func=np.mean):
     return daily
 \end{verbatim}
 
-The parameter, {\tt transactions}, is a DataFrame that contains
-columns {\tt date} and {\tt ppg}.  We select these two
-columns, then group by {\tt date}.
+The parameter, \verb"transactions", is a DataFrame that contains
+columns \verb"date" and \verb"ppg".  We select these two
+columns, then group by \verb"date".
 \index{groupby}
 
-The result, {\tt grouped}, is a map from each date to a DataFrame that
-contains prices reported on that date.  {\tt aggregate} is a
+The result, \verb"grouped", is a map from each date to a DataFrame that
+contains prices reported on that date.  \verb"aggregate" is a
 GroupBy method that iterates through the groups and applies a
 function to each column of the group; in this case there is only one
-column, {\tt ppg}.  So the result of {\tt aggregate} is a DataFrame
-with one row for each date and one column, {\tt ppg}.
+column, \verb"ppg".  So the result of \verb"aggregate" is a DataFrame
+with one row for each date and one column, \verb"ppg".
 \index{aggregate}
 
-Dates in these DataFrames are stored as NumPy {\tt datetime64}
+Dates in these DataFrames are stored as NumPy \verb"datetime64"
 objects, which are represented as 64-bit integers in nanoseconds.
 For some of the analyses coming up, it will be convenient to
 work with time in more human-friendly units, like years.  So
-{\tt GroupByDay} adds a column named {\tt date} by copying
-the {\tt index}, then adds {\tt years}, which contains the number
+\verb"GroupByDay" adds a column named \verb"date" by copying
+the \verb"index", then adds \verb"years", which contains the number
 of years since the first transaction as a floating-point number.
 \index{NumPy}
 \index{datetime64}
 
-The resulting DataFrame has columns {\tt ppg}, {\tt date}, and
-{\tt years}.
+The resulting DataFrame has columns \verb"ppg", \verb"date", and
+\verb"years".
 \index{DataFrame}
 
 
 \section{Plotting}
 
-The result from {\tt GroupByQualityAndDay} is a map from each quality
+The result from \verb"GroupByQualityAndDay" is a map from each quality
 to a DataFrame of daily prices.  Here's the code I use to plot
 the three time series:
 \index{DataFrame}
@@ -9530,7 +9527,7 @@ the three time series:
             thinkplot.Config(xticks=[])
 \end{verbatim}
 
-{\tt PrePlot} with {\tt rows=3} means that we are planning to
+\verb"PrePlot" with \verb"rows=3" means that we are planning to
 make three subplots laid out in three rows.  The loop iterates
 through the DataFrames and creates a scatter plot for each.  It is
 common to plot time series with line segments between the points,
@@ -9538,7 +9535,7 @@ but in this case there are many data points and prices are highly
 variable, so adding lines would not help.
 \index{thinkplot}
 
-Since the labels on the x-axis are dates, I use {\tt pyplot.xticks}
+Since the labels on the x-axis are dates, I use \verb"pyplot.xticks"
 to rotate the ``ticks'' 30 degrees, making them more readable.
 \index{pyplot}
 \index{ticks}
@@ -9635,8 +9632,8 @@ def PlotFittedValues(model, results, label=''):
     thinkplot.Plot(years, results.fittedvalues, label='model')
 \end{verbatim}
 
-As we saw in Section~\ref{implementation}, {\tt model} contains
-{\tt exog} and {\tt endog}, NumPy arrays with the exogenous
+As we saw in Section~\ref{implementation}, \verb"model" contains
+\verb"exog" and \verb"endog", NumPy arrays with the exogenous
 (explanatory) and endogenous (dependent) variables.
 \index{NumPy}
 \index{explanatory variable}
@@ -9652,7 +9649,7 @@ and a linear least squares fit.}
 \label{timeseries2}
 \end{figure}
 
-{\tt PlotFittedValues} makes a scatter plot of the data points and a line
+\verb"PlotFittedValues" makes a scatter plot of the data points and a line
 plot of the fitted values.  Figure~\ref{timeseries2} shows the results
 for high quality cannabis.  The model seems like a good linear fit
 for the data; nevertheless, linear regression is not the most 
@@ -9732,7 +9729,7 @@ array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 array([ nan,  nan,   1,   2,   3,   4,   5,   6,   7,   8])
 \end{verbatim}
 
-The first two values are {\tt nan}; the next value is the mean of
+The first two values are \verb"nan"; the next value is the mean of
 the first three elements, 0, 1, and 2.  The next value is the mean
 of 1, 2, and 3.  And so on.
 
@@ -9757,8 +9754,8 @@ that by ``reindexing'' the DataFrame:
 
 The first line computes a date range that includes every day from the
 beginning to the end of the observed interval.  The second line
-creates a new DataFrame with all of the data from {\tt daily}, but
-including rows for all dates, filled with {\tt nan}.
+creates a new DataFrame with all of the data from \verb"daily", but
+including rows for all dates, filled with \verb"nan".
 \index{interval}
 \index{date range}
 
@@ -9770,7 +9767,7 @@ Now we can plot the rolling mean like this:
 \end{verbatim}
 
 The window size is 30, so each value in \verb"roll_mean" is
-the mean of 30 values from {\tt reindexed.ppg}.  
+the mean of 30 values from \verb"reindexed.ppg".  
 \index{pandas}
 \index{window}
 
@@ -9785,8 +9782,8 @@ moving average (right).}
 Figure~\ref{timeseries10} (left)
 shows the result. 
 The rolling mean seems to do a good job of smoothing out the noise and
-extracting the trend.  The first 29 values are {\tt nan}, and wherever
-there's a missing value, it's followed by another 29 {\tt nan}s.
+extracting the trend.  The first 29 values are \verb"nan", and wherever
+there's a missing value, it's followed by another 29 \verb"nan"s.
 There are ways to fill in these gaps, but they are a minor nuisance.
 \index{missing values}
 \index{noise}
@@ -9834,7 +9831,7 @@ missing data, so we have to solve that problem first.
 \index{seasonality}
 
 A simple and common way to fill missing data is to use a moving
-average.  The Series method {\tt fillna} does just what we want:
+average.  The Series method \verb"fillna" does just what we want:
 \index{Series}
 \index{fillna}
 
@@ -9842,9 +9839,9 @@ average.  The Series method {\tt fillna} does just what we want:
     reindexed.ppg.fillna(ewma, inplace=True)
 \end{verbatim}
 
-Wherever {\tt reindexed.ppg} is {\tt nan}, {\tt fillna} replaces
-it with the corresponding value from {\tt ewma}.  The {\tt inplace}
-flag tells {\tt fillna} to modify the existing Series rather than
+Wherever \verb"reindexed.ppg" is \verb"nan", \verb"fillna" replaces
+it with the corresponding value from \verb"ewma".  The \verb"inplace"
+flag tells \verb"fillna" to modify the existing Series rather than
 create a new one.
 
 A drawback of this method is that it understates the noise in the
@@ -9866,10 +9863,10 @@ residuals:
 %time between measurements in a series.  I don't use the second
 %meaning in this book, but you might encounter it.)
 
-{\tt resid} contains the residual values, not including days
-when {\tt ppg} is {\tt nan}.  \verb"fake_data" contains the
+\verb"resid" contains the residual values, not including days
+when \verb"ppg" is \verb"nan".  \verb"fake_data" contains the
 sum of the moving average and a random sample of residuals.
-Finally, {\tt fillna} replaces {\tt nan} with values from
+Finally, \verb"fillna" replaces \verb"nan" with values from
 \verb"fake_data".
 \index{dropna}
 \index{fillna}
@@ -9915,15 +9912,15 @@ def SerialCorr(series, lag=1):
     return corr
 \end{verbatim}
 
-After the shift, the first {\tt lag} values are {\tt nan}, so
-I use a slice to remove them before computing {\tt Corr}.
+After the shift, the first \verb"lag" values are \verb"nan", so
+I use a slice to remove them before computing \verb"Corr".
 \index{NaN}
 
 %high 0.480121816154
 %medium 0.164600078362
 %low 0.103373620131
 
-If we apply {\tt SerialCorr} to the raw price data with lag 1, we find
+If we apply \verb"SerialCorr" to the raw price data with lag 1, we find
 serial correlation 0.48 for the high quality category, 0.16 for
 medium and 0.10 for low.  In any time series with a long-term trend,
 we expect to see strong serial correlations; for example, if prices
@@ -9981,7 +9978,7 @@ name for serial correlation, used more often when the lag is not 1.
 
 StatsModels, which we used for linear regression in
 Section~\ref{statsmodels}, also provides functions for time series
-analysis, including {\tt acf}, which computes the autocorrelation
+analysis, including \verb"acf", which computes the autocorrelation
 function:
 \index{StatsModels}
 
@@ -9990,12 +9987,12 @@ function:
     acf = smtsa.acf(filled.resid, nlags=365, unbiased=True)
 \end{verbatim}
 
-{\tt acf} computes serial correlations with
-lags from 0 through {\tt nlags}.  The {\tt unbiased} flag tells
-{\tt acf} to correct the estimates for the sample size.  The result
+\verb"acf" computes serial correlations with
+lags from 0 through \verb"nlags".  The \verb"unbiased" flag tells
+\verb"acf" to correct the estimates for the sample size.  The result
 is an array of correlations.  If we select daily prices for high
 quality, and extract correlations for lags 1, 7, 30, and 365, we can
-confirm that {\tt acf} and {\tt SerialCorr} yield approximately
+confirm that \verb"acf" and \verb"SerialCorr" yield approximately
 the same results:
 \index{acf}
 
@@ -10004,7 +10001,7 @@ the same results:
 1.000, -0.029, 0.020, 0.014, 0.044
 \end{verbatim}
 
-With {\tt lag=0}, {\tt acf} computes the correlation of the series
+With \verb"lag=0", \verb"acf" computes the correlation of the series
 with itself, which is always 1.
 \index{lag}
 
@@ -10017,7 +10014,7 @@ daily prices with a simulated weekly seasonality (right).}
 \end{figure}
 
 Figure~\ref{timeseries9} (left) shows autocorrelation functions for
-the three quality categories, with {\tt nlags=40}.  The gray region
+the three quality categories, with \verb"nlags=40".  The gray region
 shows the normal variability we would expect if there is no actual
 autocorrelation; anything that falls outside this range is
 statistically significant, with a p-value less than 5\%.  Since
@@ -10031,8 +10028,8 @@ in these series that could not be explained by chance.
 \index{false positive}
 
 I computed the gray regions by resampling the residuals.  You
-can see my code in {\tt timeseries.py}; the function is called
-{\tt SimulateAutocorrelation}.
+can see my code in \verb"timeseries.py"; the function is called
+\verb"SimulateAutocorrelation".
 \index{resampling}
 
 To see what the autocorrelation function looks like when there is a
@@ -10053,10 +10050,10 @@ def AddWeeklySeasonality(daily):
     return fake
 \end{verbatim}
 
-{\tt frisat} is a boolean Series, {\tt True} if the day of the
-week is Friday or Saturday.  {\tt fake} is a new DataFrame, initially
-a copy of {\tt daily}, which we modify by adding random values
-to {\tt ppg}.  {\tt frisat.sum()} is the total number of Fridays
+\verb"frisat" is a boolean Series, \verb"True" if the day of the
+week is Friday or Saturday.  \verb"fake" is a new DataFrame, initially
+a copy of \verb"daily", which we modify by adding random values
+to \verb"ppg".  \verb"frisat.sum()" is the total number of Fridays
 and Saturdays, which is the number of random values we have to
 generate.
 \index{DataFrame}
@@ -10083,8 +10080,8 @@ make predictions.
 \index{prediction}
 
 The linear regressions we used in Section~\ref{timeregress} can be
-used for prediction.  The RegressionResults class provides {\tt
-  predict}, which takes a DataFrame containing the explanatory
+used for prediction.  The RegressionResults class provides \verb"predict",
+which takes a DataFrame containing the explanatory
 variables and returns a sequence of predictions.  Here's the code:
 \index{explanatory variable}
 \index{linear regression}
@@ -10099,9 +10096,9 @@ def GenerateSimplePrediction(results, years):
     return predict
 \end{verbatim}
 
-{\tt results} is a RegressionResults object; {\tt years} is the
+\verb"results" is a RegressionResults object; \verb"years" is the
 sequence of time values we want predictions for.  The function
-constructs a DataFrame, passes it to {\tt predict}, and
+constructs a DataFrame, passes it to \verb"predict", and
 returns the result.
 \index{pandas}
 \index{DataFrame}
@@ -10166,12 +10163,12 @@ def SimulateResults(daily, iters=101):
     return result_seq
 \end{verbatim}
 
-{\tt daily} is a DataFrame containing the observed prices;
-{\tt iters} is the number of simulations to run.
+\verb"daily" is a DataFrame containing the observed prices;
+\verb"iters" is the number of simulations to run.
 \index{DataFrame}
 \index{price}
 
-{\tt SimulateResults} uses {\tt RunLinearModel}, from
+\verb"SimulateResults" uses \verb"RunLinearModel", from
 Section~\ref{timeregress}, to estimate the slope and intercept
 of the observed values.
 
@@ -10200,12 +10197,12 @@ def GeneratePredictions(result_seq, years, add_resid=False):
     return predict_seq
 \end{verbatim}
 
-{\tt GeneratePredictions} takes the sequence of results from the
-previous step, as well as {\tt years}, which is a sequence of
+\verb"GeneratePredictions" takes the sequence of results from the
+previous step, as well as \verb"years", which is a sequence of
 floats that specifies the interval to generate predictions for,
 and \verb"add_resid", which indicates whether it should add resampled
 residuals to the straight-line prediction.
-{\tt GeneratePredictions} iterates through the sequence of
+\verb"GeneratePredictions" iterates through the sequence of
 RegressionResults and generates a sequence of predictions.
 \index{resampling}
 
@@ -10236,9 +10233,9 @@ def PlotPredictions(daily, years, iters=101, percent=90):
     thinkplot.FillBetween(years, low, high, alpha=0.5, color='gray')
 \end{verbatim}
 
-{\tt PlotPredictions} calls {\tt GeneratePredictions} twice: once
+\verb"PlotPredictions" calls \verb"GeneratePredictions" twice: once
 with \verb"add_resid=True" and again with \verb"add_resid=False".
-It uses {\tt PercentileRows} to select the 5th and 95th percentiles
+It uses \verb"PercentileRows" to select the 5th and 95th percentiles
 for each year, then plots a gray region between these bounds.
 \index{FillBetween}
 
@@ -10275,9 +10272,9 @@ half than the second.
 
 As a result, the parameters we get depend on the interval we
 observe.  To see how much effect this has on the predictions,
-we can extend {\tt SimulateResults} to use intervals of observation
+we can extend \verb"SimulateResults" to use intervals of observation
 with different start and end dates.  My implementation is in
-{\tt timeseries.py}.
+\verb"timeseries.py".
 \index{simulation}
 
 \begin{figure}
@@ -10336,16 +10333,16 @@ as we did in Section~\ref{nonlinear}.
 
 Use a quadratic model to fit the time series of daily prices,
 and use the model to generate predictions.  You will have to
-write a version of {\tt RunLinearModel} that runs that quadratic
+write a version of \verb"RunLinearModel" that runs that quadratic
 model, but after that you should be able to reuse code in
-{\tt timeseries.py} to generate predictions.
+\verb"timeseries.py" to generate predictions.
 \index{prediction}
 
 \end{exercise}
 
 \begin{exercise}
-Write a definition for a class named {\tt SerialCorrelationTest}
-that extends {\tt HypothesisTest} from Section~\ref{hypotest}.
+Write a definition for a class named \verb"SerialCorrelationTest"
+that extends \verb"HypothesisTest" from Section~\ref{hypotest}.
 It should take a series and a lag as data, compute the serial
 correlation of the series with the given lag, and then compute
 the p-value of the observed correlation.
@@ -10370,14 +10367,14 @@ One of the simplest is something like this:
 \begin{enumerate}
 
 \item Compute the EWMA of the time series and use the last point
-as an intercept, {\tt inter}.
+as an intercept, \verb"inter".
 
 \item Compute the EWMA of differences between successive elements in
-the time series and use the last point as a slope, {\tt slope}.
+the time series and use the last point as a slope, \verb"slope".
 \index{slope}
 
-\item To predict values at future times, compute {\tt inter + slope * dt},
-where {\tt dt} is the difference between the time of the prediction and
+\item To predict values at future times, compute \verb"inter + slope * dt",
+where \verb"dt" is the difference between the time of the prediction and
 the time of the last observation.
 \index{prediction}
 
@@ -10388,19 +10385,19 @@ observation.  A few hints:
 
 \begin{itemize}
 
-\item Use {\tt timeseries.FillMissing} to fill in missing values
+\item Use \verb"timeseries.FillMissing" to fill in missing values
 before running this analysis.  That way the time between consecutive
 elements is consistent.
 \index{missing values}
 
-\item Use {\tt Series.diff} to compute differences between successive
+\item Use \verb"Series.diff" to compute differences between successive
 elements.
 \index{Series}
 
-\item Use {\tt reindex} to extend the DataFrame index into the future.
+\item Use \verb"reindex" to extend the DataFrame index into the future.
 \index{reindex}
 
-\item Use {\tt fillna} to put your predicted values into the DataFrame.
+\item Use \verb"fillna" to put your predicted values into the DataFrame.
 \index{fillna}
 
 \end{itemize}
@@ -10479,7 +10476,7 @@ is the probability of surviving five years after diagnosis.  That
 estimate and related statistics are the result of survival analysis.
 \index{survival rate}
 
-The code in this chapter is in {\tt survival.py}.  For information
+The code in this chapter is in \verb"survival.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
@@ -10508,12 +10505,12 @@ complete pregnancies.  We can read this data and compute the CDF:
     cdf = thinkstats2.Cdf(complete, label='cdf')
 \end{verbatim}
 
-The outcome codes {\tt 1, 3, 4} indicate live birth, stillbirth,
+The outcome codes \verb"1, 3, 4" indicate live birth, stillbirth,
 and miscarriage.  For this analysis I am excluding induced abortions,
 ectopic pregnancies, and pregnancies that were in progress when
 the respondent was interviewed.
 
-The DataFrame method {\tt query} takes a boolean expression and
+The DataFrame method \verb"query" takes a boolean expression and
 evaluates it for each row, selecting the rows that yield True.
 \index{DataFrame}
 \index{boolean}
@@ -10550,12 +10547,12 @@ class SurvivalFunction(object):
         return 1 - self.cdf.ps
 \end{verbatim}
 
-{\tt SurvivalFunction} provides two properties: {\tt ts}, which
-is the sequence of lifetimes, and {\tt ss}, which is the survival
+\verb"SurvivalFunction" provides two properties: \verb"ts", which
+is the sequence of lifetimes, and \verb"ss", which is the survival
 curve.  In Python, a ``property'' is a method that can be
 invoked as if it were a variable.
 
-We can instantiate a {\tt SurvivalFunction} by passing
+We can instantiate a \verb"SurvivalFunction" by passing
 the CDF of lifetimes:
 \index{property}
 
@@ -10563,8 +10560,8 @@ the CDF of lifetimes:
     sf = SurvivalFunction(cdf)
 \end{verbatim}
 
-{\tt SurvivalFunction} also provides \verb"__getitem__" and
-{\tt Prob}, which evaluates the survival curve:
+\verb"SurvivalFunction" also provides \verb"__getitem__" and
+\verb"Prob", which evaluates the survival curve:
 
 \begin{verbatim}
 # class SurvivalFunction
@@ -10576,7 +10573,7 @@ the CDF of lifetimes:
         return 1 - self.cdf.Prob(t)
 \end{verbatim}
 
-For example, {\tt sf[13]} is the fraction of pregnancies that
+For example, \verb"sf[13]" is the fraction of pregnancies that
 proceed past the first trimester:
 \index{trimester}
 
@@ -10590,8 +10587,8 @@ proceed past the first trimester:
 About 86\% of pregnancies proceed past the first trimester;
 about 14\% do not.
 
-{\tt SurvivalFunction} provides {\tt Render}, so we can
-plot {\tt sf} using the functions in {\tt thinkplot}:
+\verb"SurvivalFunction" provides \verb"Render", so we can
+plot \verb"sf" using the functions in \verb"thinkplot":
 \index{thinkplot}
 
 \begin{verbatim}
@@ -10619,7 +10616,7 @@ The numerator is the fraction of lifetimes that end at $t$, which
 is also $\PMF(t)$.
 \index{hazard function}
 
-{\tt SurvivalFunction} provides {\tt MakeHazard}, which calculates
+\verb"SurvivalFunction" provides \verb"MakeHazard", which calculates
 the hazard function:
 
 \begin{verbatim}
@@ -10635,7 +10632,7 @@ the hazard function:
         return HazardFunction(lams, label=label)
 \end{verbatim}
 
-The {\tt HazardFunction} object is a wrapper for a pandas
+The \verb"HazardFunction" object is a wrapper for a pandas
 Series:
 \index{pandas}
 \index{Series}
@@ -10649,12 +10646,12 @@ class HazardFunction(object):
         self.label = label
 \end{verbatim}
 
-{\tt d} can be a dictionary or any other type that can initialize
-a Series, including another Series.  {\tt label} is a string used
+\verb"d" can be a dictionary or any other type that can initialize
+a Series, including another Series.  \verb"label" is a string used
 to identify the HazardFunction when plotted.
 \index{HazardFunction}
 
-{\tt HazardFunction} provides \verb"__getitem__", so we can evaluate
+\verb"HazardFunction" provides \verb"__getitem__", so we can evaluate
 it like this:
 
 \begin{verbatim}
@@ -10765,8 +10762,8 @@ def EstimateHazardFunction(complete, ongoing, label=''):
     return HazardFunction(lams, label=label)
 \end{verbatim}
 
-{\tt complete} is the set of complete observations; in this case,
-the ages when respondents got married.  {\tt ongoing} is the set
+\verb"complete" is the set of complete observations; in this case,
+the ages when respondents got married.  \verb"ongoing" is the set
 of incomplete observations; that is, the ages of unmarried women
 when they were interviewed.
 
@@ -10778,7 +10775,7 @@ number of unmarried women interviewed at that age.
 \index{Counter}
 \index{survival curve}
 
-{\tt ts} is the union of ages when respondents got married
+\verb"ts" is the union of ages when respondents got married
 and ages when unmarried women were interviewed, sorted in
 increasing order.
 
@@ -10786,24 +10783,24 @@ increasing order.
 ``at risk'' at each age; initially, it is the total number of
 respondents.
 
-The result is stored in a Pandas {\tt Series} that maps from
+The result is stored in a Pandas \verb"Series" that maps from
 each age to the estimated hazard function at that age.
 
-Each time through the loop, we consider one age, {\tt t},
-and compute the number of events that end at {\tt t} (that is,
+Each time through the loop, we consider one age, \verb"t",
+and compute the number of events that end at \verb"t" (that is,
 the number of respondents married at that age) and the number
-of events censored at {\tt t} (that is, the number of women
-interviewed at {\tt t} whose future marriage dates are
+of events censored at \verb"t" (that is, the number of women
+interviewed at \verb"t" whose future marriage dates are
 censored).  In this context, ``censored'' means that the
 data are unavailable because of the data collection process.
 
 The estimated hazard function is the fraction of the cases
-at risk that end at {\tt t}.
+at risk that end at \verb"t".
 
 At the end of the loop, we subtract from \verb"at_risk" the
-number of cases that ended or were censored at {\tt t}.
+number of cases that ended or were censored at \verb"t".
 
-Finally, we pass {\tt lams} to the {\tt HazardFunction}
+Finally, we pass \verb"lams" to the \verb"HazardFunction"
 constructor and return the result.
 
 \index{HazardFunction}
@@ -10817,17 +10814,17 @@ transformation.  The NSFG variables we need are:
 
 \begin{itemize}
 
-\item {\tt cmbirth}: The respondent's date of birth, known for
+\item \verb"cmbirth": The respondent's date of birth, known for
 all respondents.
 \index{date of birth}
 
-\item {\tt cmintvw}: The date the respondent was interviewed,
+\item \verb"cmintvw": The date the respondent was interviewed,
 known for all respondents.
 
-\item {\tt cmmarrhx}: The date the respondent was first married,
+\item \verb"cmmarrhx": The date the respondent was first married,
 if applicable and known.
 
-\item {\tt evrmarry}: 1 if the respondent had been
+\item \verb"evrmarry": 1 if the respondent had been
 married prior to the date of interview, 0 otherwise.
 
 \end{itemize}
@@ -10838,7 +10835,7 @@ integer number of months since December 1899.  So century-month
 \index{century month}
 
 First, we read the respondent file and replace invalid values of
-{\tt cmmarrhx}:
+\verb"cmmarrhx":
 
 \begin{verbatim}
     resp = chap01soln.ReadFemResp()
@@ -10854,8 +10851,8 @@ interviewed:
     resp['age'] = (resp.cmintvw - resp.cmbirth) / 12.0
 \end{verbatim}
 
-Next we extract {\tt complete}, which is the age at marriage for
-women who have been married, and {\tt ongoing}, which is the
+Next we extract \verb"complete", which is the age at marriage for
+women who have been married, and \verb"ongoing", which is the
 age at interview for women who have not:
 \index{age}
 
@@ -10885,13 +10882,13 @@ curve will smooth out this noise.
 \section{Estimating the survival curve}
 
 Once we have the hazard function, we can estimate the survival curve.
-The chance of surviving past time {\tt t} is the chance of surviving
-all times up through {\tt t}, which is the cumulative product of
+The chance of surviving past time \verb"t" is the chance of surviving
+all times up through \verb"t", which is the cumulative product of
 the complementary hazard function:
 %
 \[ [1-\lambda(0)] [1-\lambda(1)] ... [1-\lambda(t)] \]
 %
-The {\tt HazardFunction} class provides {\tt MakeSurvival}, which
+The \verb"HazardFunction" class provides \verb"MakeSurvival", which
 computes this product:
 \index{cumulative product}
 \index{SurvivalFunction}
@@ -10907,12 +10904,12 @@ computes this product:
         return sf
 \end{verbatim}
 
-{\tt ts} is the sequence of times where the hazard function is
-estimated.  {\tt ss} is the cumulative product of the complementary
+\verb"ts" is the sequence of times where the hazard function is
+estimated.  \verb"ss" is the cumulative product of the complementary
 hazard function, so it is the survival curve.
 
-Because of the way {\tt SurvivalFunction} is implemented, we have
-to compute the complement of {\tt ss}, make a Cdf, and then instantiate
+Because of the way \verb"SurvivalFunction" is implemented, we have
+to compute the complement of \verb"ss", make a Cdf, and then instantiate
 a SurvivalFunction object.
 \index{Cdf}
 \index{complementary CDF}
@@ -10983,29 +10980,29 @@ def ResampleSurvival(resp, iters=101):
     thinkplot.FillBetween(ts, low, high)
 \end{verbatim}
 
-{\tt ResampleSurvival} takes {\tt resp}, a DataFrame of respondents,
-and {\tt iters}, the number of times to resample.  It computes {\tt
-  ts}, which is the sequence of ages where we will evaluate the survival
+\verb"ResampleSurvival" takes \verb"resp", a DataFrame of respondents,
+and \verb"iters", the number of times to resample.  It computes \verb"ts",
+which is the sequence of ages where we will evaluate the survival
 curves.
 \index{DataFrame}
 
-Inside the loop, {\tt ResampleSurvival}:
+Inside the loop, \verb"ResampleSurvival":
 
 \begin{itemize}
 
-\item Resamples the respondents using {\tt ResampleRowsWeighted},
+\item Resamples the respondents using \verb"ResampleRowsWeighted",
 which we saw in Section~\ref{weighted}.
 \index{weighted resampling}
 
-\item Calls {\tt EstimateSurvival}, which uses the process in the
+\item Calls \verb"EstimateSurvival", which uses the process in the
 previous sections to estimate the hazard and survival curves, and
 
-\item Evaluates the survival curve at each age in {\tt ts}.
+\item Evaluates the survival curve at each age in \verb"ts".
 
 \end{itemize}
 
 \verb"ss_seq" is a sequence of evaluated survival curves.
-{\tt PercentileRows} takes this sequence and computes the 5th and 95th
+\verb"PercentileRows" takes this sequence and computes the 5th and 95th
 percentiles, returning a 90\% confidence interval for the survival
 curve.
 \index{FillBetween}
@@ -11032,8 +11029,8 @@ to keep that in mind.
 
 One of the challenges of survival analysis is that different parts
 of the estimated curve are based on different groups of respondents.
-The part of the curve at time {\tt t} is based on respondents
-whose age was at least {\tt t} when they were interviewed.
+The part of the curve at time \verb"t" is based on respondents
+whose age was at least \verb"t" when they were interviewed.
 So the leftmost part of the curve includes data from all respondents,
 but the rightmost part includes only the oldest respondents.
 
@@ -11060,7 +11057,7 @@ and the Cycle 5 data from 1995.  In total these datasets include
     resps = [resp5, resp6, resp7]
 \end{verbatim}
 
-For each DataFrame, {\tt resp}, I use {\tt cmbirth} to compute the
+For each DataFrame, \verb"resp", I use \verb"cmbirth" to compute the
 decade of birth for each respondent:
 \index{pandas}
 \index{DataFrame}
@@ -11072,12 +11069,12 @@ decade of birth for each respondent:
     resp['decade'] = (pandas.DatetimeIndex(dates).year - 1900) // 10
 \end{verbatim}
 
-{\tt cmbirth} is encoded as the integer number of months since
-December 1899; {\tt month0} represents that date as a Timestamp
-object.  For each birth date, we instantiate a {\tt DateOffset} that
-contains the century-month and add it to {\tt month0}; the result
-is a sequence of Timestamps, which is converted to a {\tt
-  DateTimeIndex}.  Finally, we extract {\tt year} and compute
+\verb"cmbirth" is encoded as the integer number of months since
+December 1899; \verb"month0" represents that date as a Timestamp
+object.  For each birth date, we instantiate a \verb"DateOffset" that
+contains the century-month and add it to \verb"month0"; the result
+is a sequence of Timestamps, which is converted to a \verb"DateTimeIndex".
+Finally, we extract \verb"year" and compute
 decades.
 \index{DateTimeIndex}
 \index{Index}
@@ -11100,15 +11097,15 @@ group respondents by decade, and plot survival curves:
 \end{verbatim}
 
 Data from the three NSFG cycles use different sampling weights,
-so I resample them separately and then use {\tt concat}
+so I resample them separately and then use \verb"concat"
 to merge them into a single DataFrame.  The parameter \verb"ignore_index"
-tells {\tt concat} not to match up respondents by index; instead
+tells \verb"concat" not to match up respondents by index; instead
 it creates a new index from 0 to 30768.
 \index{pandas}
 \index{DataFrame}
 \index{groupby}
 
-{\tt EstimateSurvivalByDecade} plots survival curves for each cohort:
+\verb"EstimateSurvivalByDecade" plots survival curves for each cohort:
 
 \begin{verbatim}
 def EstimateSurvivalByDecade(resp):
@@ -11169,7 +11166,7 @@ we hardly have any data at all.
 \index{extrapolation}
 
 We can extrapolate these curves by ``borrowing'' data from the
-previous cohort.  HazardFunction provides a method, {\tt Extend}, that
+previous cohort.  HazardFunction provides a method, \verb"Extend", that
 copies the tail from another longer HazardFunction:
 \index{HazardFunction}
 
@@ -11183,10 +11180,10 @@ copies the tail from another longer HazardFunction:
 \end{verbatim}
 
 As we saw in Section~\ref{hazard}, the HazardFunction contains a Series
-that maps from $t$ to $\lambda(t)$.  {\tt Extend} finds {\tt last},
-which is the last index in {\tt self.series}, selects values from
-{\tt other} that come later than {\tt last}, and appends them
-onto {\tt self.series}.
+that maps from $t$ to $\lambda(t)$.  \verb"Extend" finds \verb"last",
+which is the last index in \verb"self.series", selects values from
+\verb"other" that come later than \verb"last", and appends them
+onto \verb"self.series".
 \index{pandas}
 \index{Series}
 
@@ -11208,7 +11205,7 @@ def PlotPredictionsByDecade(groups):
         thinkplot.Plot(sf)
 \end{verbatim}
 
-{\tt groups} is a GroupBy object with respondents grouped by decade of
+\verb"groups" is a GroupBy object with respondents grouped by decade of
 birth.  The first loop computes the HazardFunction for each group.
 \index{groupby}
 
@@ -11240,7 +11237,7 @@ survival curve of pregnancy length from Section~\ref{survival},
 we can compute the expected time until delivery.
 \index{pregnancy length}
 
-The first step is to extract the PMF of lifetimes.  {\tt SurvivalFunction}
+The first step is to extract the PMF of lifetimes.  \verb"SurvivalFunction"
 provides a method that does that:
 
 \begin{verbatim}
@@ -11264,9 +11261,9 @@ a Pmf.
 \index{Pmf}
 \index{Cdf}
 
-{\tt cutoff} is the highest probability in the Cdf, which is 1
+\verb"cutoff" is the highest probability in the Cdf, which is 1
 if the Cdf is complete, and otherwise less than 1.  
-If the Cdf is incomplete, we plug in the provided value, {\tt filler},
+If the Cdf is incomplete, we plug in the provided value, \verb"filler",
 to cap it off.
 
 The Cdf of pregnancy lengths is complete, so we don't have to worry
@@ -11274,7 +11271,7 @@ about this detail yet.
 \index{pregnancy length}
 
 The next step is to compute the expected remaining lifetime, where
-``expected'' means average.  {\tt SurvivalFunction}
+``expected'' means average.  \verb"SurvivalFunction"
 provides a method that does that, too:
 \index{expected remaining lifetime}
 
@@ -11292,24 +11289,24 @@ provides a method that does that, too:
         return pandas.Series(d)
 \end{verbatim}
 
-{\tt RemainingLifetime} takes {\tt filler}, which is passed along
-to {\tt MakePmf}, and {\tt func} which is the function used to
+\verb"RemainingLifetime" takes \verb"filler", which is passed along
+to \verb"MakePmf", and \verb"func" which is the function used to
 summarize the distribution of remaining lifetimes.
 
-{\tt pmf} is the Pmf of lifetimes extracted from the SurvivalFunction.
-{\tt d} is a dictionary that contains the results, a map from
-current age, {\tt t}, to expected remaining lifetime.
+\verb"pmf" is the Pmf of lifetimes extracted from the SurvivalFunction.
+\verb"d" is a dictionary that contains the results, a map from
+current age, \verb"t", to expected remaining lifetime.
 \index{Pmf}
 
 The loop iterates through the values in the Pmf.  For each value
-of {\tt t} it computes the conditional distribution of lifetimes,
-given that the lifetime exceeds {\tt t}.  It does that by removing
+of \verb"t" it computes the conditional distribution of lifetimes,
+given that the lifetime exceeds \verb"t".  It does that by removing
 values from the Pmf one at a time and renormalizing the remaining
 values.
 
-Then it uses {\tt func} to summarize the conditional distribution.
+Then it uses \verb"func" to summarize the conditional distribution.
 In this example the result is the mean pregnancy length, given that
-the length exceeds {\tt t}.  By subtracting {\tt t} we get the
+the length exceeds \verb"t".  By subtracting \verb"t" we get the
 mean remaining pregnancy length.
 \index{pregnancy length}
 
@@ -11369,7 +11366,7 @@ so we can't compute a mean.
 \index{Cdf}
 \index{median}
 
-I deal with these unknown values by replacing them with {\tt np.inf},
+I deal with these unknown values by replacing them with \verb"np.inf",
 a special value that represents infinity.  That makes the mean
 infinity for all ages, but the median is well-defined as long as
 more than 50\% of the remaining lifetimes are finite, which is true
@@ -11388,12 +11385,12 @@ Here's the code that computes and plots these functions:
     thinkplot.Plot(rem_life2)
 \end{verbatim}
 
-{\tt sf1} is the survival curve for pregnancy length;
-in this case we can use the default values for {\tt RemainingLifetime}.
+\verb"sf1" is the survival curve for pregnancy length;
+in this case we can use the default values for \verb"RemainingLifetime".
 \index{pregnancy length}
 
-{\tt sf2} is the survival curve for age at first marriage;
-{\tt func} is a function that takes a Pmf and computes its
+\verb"sf2" is the survival curve for age at first marriage;
+\verb"func" is a function that takes a Pmf and computes its
 median (50th percentile).
 \index{Pmf}
 
@@ -11403,7 +11400,7 @@ median (50th percentile).
 My solution to this exercise is in \verb"chap13soln.py".
 
 \begin{exercise}
-In NSFG Cycles 6 and 7, the variable {\tt cmdivorcx} contains the
+In NSFG Cycles 6 and 7, the variable \verb"cmdivorcx" contains the
 date of divorce for the respondent's first marriage, if applicable,
 encoded in century-months.
 \index{divorce}
@@ -11477,7 +11474,7 @@ how they work.  At the end of the chapter, I make suggestions
 for integrating computational and analytic methods for exploratory
 data analysis.
 
-The code in this chapter is in {\tt normal.py}.  For information
+The code in this chapter is in \verb"normal.py".  For information
 about downloading and working with this code, see Section~\ref{code}.
 
 
@@ -11626,7 +11623,7 @@ CDF.
 There is no closed form for the CDF of the normal distribution
 or its inverse, but there are fast numerical methods and they
 are implemented in SciPy, as we saw in Section~\ref{normal}.
-{\tt thinkstats2} provides a wrapper function that makes the
+\verb"thinkstats2" provides a wrapper function that makes the
 SciPy function a little easier to use:
 \index{SciPy}
 \index{normal distribution}
@@ -11638,9 +11635,9 @@ def EvalNormalCdfInverse(p, mu=0, sigma=1):
     return scipy.stats.norm.ppf(p, loc=mu, scale=sigma)
 \end{verbatim}
 
-Given a probability, {\tt p}, it returns the corresponding
-percentile from a normal distribution with parameters {\tt mu}
-and {\tt sigma}.  For the 90\% confidence interval of $\xbar$,
+Given a probability, \verb"p", it returns the corresponding
+percentile from a normal distribution with parameters \verb"mu"
+and \verb"sigma".  For the 90\% confidence interval of $\xbar$,
 we compute the 5th and 95th percentiles like this:
 \index{percentile}
 
@@ -11662,7 +11659,7 @@ we got by simulation.
 \section{Representing normal distributions}
 
 To make these calculations easier, I have defined a class called
-{\tt Normal} that represents a normal distribution and encodes
+\verb"Normal" that represents a normal distribution and encodes
 the equations in the previous sections.  Here's what it looks
 like:
 \index{Normal}
@@ -11688,8 +11685,8 @@ of gorilla weights:
 N(90, 56.25)
 \end{verbatim}
 
-{\tt Normal} provides {\tt Sum}, which takes a sample size, {\tt n},
-and returns the distribution of the sum of {\tt n} values, using
+\verb"Normal" provides \verb"Sum", which takes a sample size, \verb"n",
+and returns the distribution of the sum of \verb"n" values, using
 Equation 3:
 
 \begin{verbatim}
@@ -11720,8 +11717,8 @@ size 9:
 \end{verbatim}
 
 The standard deviation of the sampling distribution is 2.5 kg, as we
-saw in the previous section.  Finally, Normal provides {\tt
-  Percentile}, which we can use to compute a confidence interval:
+saw in the previous section.  Finally, Normal provides \verb"Percentile", which
+we can use to compute a confidence interval:
 \index{standard deviation}
 \index{confidence interval}
 
@@ -11747,9 +11744,9 @@ generally have an analytic distribution.
 \index{normal distribution} \index{distribution!normal}
 \index{Gaussian distribution} \index{distribution!Gaussian}
 
-But if we add up {\tt n} values from
+But if we add up \verb"n" values from
 almost any distribution, the distribution of the sum converges to
-normal as {\tt n} increases.
+normal as \verb"n" increases.
 
 More specifically, if the distribution of the values has mean and
 standard deviation $\mu$ and $\sigma$, the distribution of the sum is
@@ -11785,7 +11782,7 @@ in practice).
 
 \item The rate of convergence depends
   on the skewness of the distribution.  Sums from an exponential
-  distribution converge for small {\tt n}.  Sums from a
+  distribution converge for small \verb"n".  Sums from a
   lognormal distribution require larger sizes.
 \index{lognormal distribution}
 \index{distribution!lognormal}
@@ -11823,23 +11820,23 @@ def MakeExpoSamples(beta=2.0, iters=1000):
     return samples
 \end{verbatim}
 
-{\tt MakeExpoSamples} generates samples of sums of exponential values
+\verb"MakeExpoSamples" generates samples of sums of exponential values
 (I use ``exponential values'' as shorthand for ``values from an
 exponential distribution'').
-{\tt beta} is the parameter of the distribution; {\tt iters}
+\verb"beta" is the parameter of the distribution; \verb"iters"
 is the number of sums to generate.
 
 To explain this function, I'll start from the inside and work my way
-out.  Each time we call {\tt np.random.exponential}, we get a sequence
-of {\tt n} exponential values and compute its sum.  {\tt sample}
-is a list of these sums, with length {\tt iters}.
+out.  Each time we call \verb"np.random.exponential", we get a sequence
+of \verb"n" exponential values and compute its sum.  \verb"sample"
+is a list of these sums, with length \verb"iters".
 \index{NumPy}
 
-It is easy to get {\tt n} and {\tt iters} confused:  {\tt n} is the
-number of terms in each sum;  {\tt iters} is the number of sums we
+It is easy to get \verb"n" and \verb"iters" confused:  \verb"n" is the
+number of terms in each sum;  \verb"iters" is the number of sums we
 compute in order to characterize the distribution of sums.
 
-The return value is a list of {\tt (n, sample)} pairs.  For
+The return value is a list of \verb"(n, sample)" pairs.  For
 each pair, we make a normal probability plot:
 \index{thinkplot}
 \index{normal probability plot}
@@ -11854,8 +11851,8 @@ def NormalPlotSamples(samples, plot=1, ylabel=''):
         plot += 1
 \end{verbatim}
 
-{\tt NormalPlotSamples} takes the list of pairs from {\tt
-  MakeExpoSamples} and generates a row of normal probability plots.
+\verb"NormalPlotSamples" takes the list of pairs from \verb"MakeExpoSamples"
+and generates a row of normal probability plots.
 \index{normal probability plot}
 
 \begin{figure}
@@ -11867,17 +11864,17 @@ lognormal values (bottom row).}
 \end{figure}
 
 Figure~\ref{normal1} (top row) shows
-the results.  With {\tt n=1}, the distribution of the sum is still
+the results.  With \verb"n=1", the distribution of the sum is still
 exponential, so the normal probability plot is not a straight line.
-But with {\tt n=10} the distribution of the sum is approximately
-normal, and with {\tt n=100} it is all but indistinguishable from
+But with \verb"n=10" the distribution of the sum is approximately
+normal, and with \verb"n=100" it is all but indistinguishable from
 normal.
 
 Figure~\ref{normal1} (bottom row) shows similar results for a
 lognormal distribution.  Lognormal distributions are generally more
 skewed than exponential distributions, so the distribution of sums
-takes longer to converge.  With {\tt n=10} the normal
-probability plot is nowhere near straight, but with {\tt n=100}
+takes longer to converge.  With \verb"n=10" the normal
+probability plot is nowhere near straight, but with \verb"n=100"
 it is approximately normal.
 \index{lognormal distribution}
 \index{distribution!lognormal}
@@ -11895,7 +11892,7 @@ Pareto distributions are even more skewed than lognormal.  Depending
 on the parameters, many Pareto distributions do not have finite mean
 and variance.  As a result, the Central Limit Theorem does not apply.
 Figure~\ref{normal2} (top row) shows distributions of sums of
-Pareto values.  Even with {\tt n=100} the normal probability plot
+Pareto values.  Even with \verb"n=100" the normal probability plot
 is far from straight.
 \index{Pareto distribution}
 \index{distribution!Pareto}
@@ -11914,8 +11911,8 @@ exponential CDF to transform the uniform values to exponential.
 \index{correlation}
 \index{random number}
 
-{\tt GenerateCorrelated} returns an iterator of {\tt n} normal values
-with serial correlation {\tt rho}:
+\verb"GenerateCorrelated" returns an iterator of \verb"n" normal values
+with serial correlation \verb"rho":
 \index{iterator}
 
 \begin{verbatim}
@@ -11930,14 +11927,14 @@ def GenerateCorrelated(rho, n):
 \end{verbatim}
 
 The first value is a standard normal value.  Each subsequent value
-depends on its predecessor: if the previous value is {\tt x}, the mean of
-the next value is {\tt x*rho}, with variance {\tt 1-rho**2}.  Note that {\tt
-  random.gauss} takes the standard deviation as the second argument,
+depends on its predecessor: if the previous value is \verb"x", the mean of
+the next value is \verb"x*rho", with variance \verb"1-rho**2".  Note that
+\verb"random.gauss" takes the standard deviation as the second argument,
 not variance.
 \index{standard deviation}
 \index{standard normal distribution}
 
-{\tt GenerateExpoCorrelated}
+\verb"GenerateExpoCorrelated"
 takes the resulting sequence and transforms it to exponential:
 
 \begin{verbatim}
@@ -11948,18 +11945,18 @@ def GenerateExpoCorrelated(rho, n):
     return expo
 \end{verbatim}
 
-{\tt normal} is a list of correlated normal values.  {\tt uniform}
-is a sequence of uniform values between 0 and 1.  {\tt expo} is
+\verb"normal" is a list of correlated normal values.  \verb"uniform"
+is a sequence of uniform values between 0 and 1.  \verb"expo" is
 a correlated sequence of exponential values.
-{\tt ppf} stands for ``percent point function,'' which is another
+\verb"ppf" stands for ``percent point function,'' which is another
 name for the inverse CDF.
 \index{inverse CDF}
 \index{CDF, inverse}
 \index{percent point function}
 
 Figure~\ref{normal2} (bottom row) shows distributions of sums of
-correlated exponential values with {\tt rho=0.9}.  The correlation
-slows the rate of convergence; nevertheless, with {\tt n=100} the
+correlated exponential values with \verb"rho=0.9".  The correlation
+slows the rate of convergence; nevertheless, with \verb"n=100" the
 normal probability plot is nearly straight.  So even though CLT
 does not strictly apply when the values are correlated, moderate
 correlations are seldom a problem in practice.
@@ -12009,7 +12006,7 @@ like this:
 \end{verbatim}
 
 Both sampling distributions are based on the same population, which is
-the pool of all live births.  {\tt SamplingDistMean} takes this
+the pool of all live births.  \verb"SamplingDistMean" takes this
 sequence of values and the sample size, and returns a Normal object
 representing the sampling distribution:
 
@@ -12020,20 +12017,20 @@ def SamplingDistMean(data, n):
     return dist.Sum(n) / n
 \end{verbatim}
 
-{\tt mean} and {\tt var} are the mean and variance of
-{\tt data}.  We approximate the distribution of the data with
-a normal distribution, {\tt dist}.  
+\verb"mean" and \verb"var" are the mean and variance of
+\verb"data".  We approximate the distribution of the data with
+a normal distribution, \verb"dist".  
 
 In this example, the data are not normally distributed, so this
-approximation is not very good.  But then we compute {\tt dist.Sum(n)
-  / n}, which is the sampling distribution of the mean of {\tt n}
+approximation is not very good.  But then we compute \verb"dist.Sum(n) / n",
+which is the sampling distribution of the mean of \verb"n"
 values.  Even if the data are not normally distributed, the sampling
 distribution of the mean is, by the Central Limit Theorem.
 \index{Central Limit Theorem}
 \index{CLT}
 
 Next, we compute the sampling distribution of the difference
-in the means.  The {\tt Normal} class knows how to perform
+in the means.  The \verb"Normal" class knows how to perform
 subtraction using Equation 2:
 \index{Normal}
 
@@ -12055,9 +12052,9 @@ the same distribution to have the same mean, on average.  The variance
 of the sampling distribution is 0.0032.
 \index{sampling distribution}
 
-{\tt Normal} provides {\tt Prob}, which evaluates the normal CDF.
-We can use {\tt Prob} to compute the probability of a
-difference as large as {\tt delta} under the null hypothesis:
+\verb"Normal" provides \verb"Prob", which evaluates the normal CDF.
+We can use \verb"Prob" to compute the probability of a
+difference as large as \verb"delta" under the null hypothesis:
 \index{null hypothesis}
 
 \begin{verbatim}
@@ -12111,7 +12108,7 @@ be computed efficiently using gamma functions.
 We can use this result to compute the sampling distribution of
 correlation under the null hypothesis; that is, if we generate
 uncorrelated sequences of normal values, what is the distribution of
-their correlation?  {\tt StudentCdf} takes the sample size, {\tt n}, and
+their correlation?  \verb"StudentCdf" takes the sample size, \verb"n", and
 returns the sampling distribution of correlation:
 \index{null hypothesis}
 \index{sampling distribution}
@@ -12124,10 +12121,10 @@ def StudentCdf(n):
     return thinkstats2.Cdf(rs, ps)
 \end{verbatim}
 
-{\tt ts} is a NumPy array of values for $t$, the transformed
-correlation.  {\tt ps} contains the corresponding probabilities,
+\verb"ts" is a NumPy array of values for $t$, the transformed
+correlation.  \verb"ps" contains the corresponding probabilities,
 computed using the CDF of the Student's t-distribution implemented in
-SciPy.  The parameter of the t-distribution, {\tt df}, stands for
+SciPy.  The parameter of the t-distribution, \verb"df", stands for
 ``degrees of freedom.''  I won't explain that term, but you can read
 about it at
 \url{http://en.wikipedia.org/wiki/Degrees_of_freedom_(statistics)}.
@@ -12145,7 +12142,7 @@ normal variables.}
 \label{normal4}
 \end{figure}
 
-To get from {\tt ts} to the correlation coefficients, {\tt rs},
+To get from \verb"ts" to the correlation coefficients, \verb"rs",
 we apply the inverse transform,
 %
 \[ r = t / \sqrt{n - 2 + t^2} \]
@@ -12173,9 +12170,9 @@ Using the analytic distribution, we can compute just how unlikely:
     p_value = 1 - scipy.stats.t.cdf(t, df=n-2)
 \end{verbatim}
 
-We compute the value of {\tt t} that corresponds to {\tt r=0.07}, and
-then evaluate the t-distribution at {\tt t}.  The result is {\tt
-  2.9e-11}.  This example demonstrates an advantage of the analytic
+We compute the value of \verb"t" that corresponds to \verb"r=0.07", and
+then evaluate the t-distribution at \verb"t".  The result is \verb"2.9e-11".
+This example demonstrates an advantage of the analytic
 method: we can compute very small p-values.  But in practice it
 usually doesn't matter.
 \index{SciPy}
@@ -12230,7 +12227,7 @@ about.
 \index{tail}
 
 We can use this distribution to compute the p-value of the
-observed test statistic, {\tt chi2}:
+observed test statistic, \verb"chi2":
 \index{test statistic}
 \index{p-value}
 
@@ -12242,8 +12239,8 @@ The result is 0.041, which is consistent with the result
 from Section~\ref{casino2}.
 
 The parameter of the chi-squared distribution is ``degrees of
-freedom'' again.  In this case the correct parameter is {\tt n-1},
-where {\tt n} is the size of the table, 6.  Choosing this parameter
+freedom'' again.  In this case the correct parameter is \verb"n-1",
+where \verb"n" is the size of the table, 6.  Choosing this parameter
 can be tricky; to be honest, I am never confident that I have it
 right until I generate something like Figure~\ref{normal5} to compare
 the analytic results to the resampling results.


### PR DESCRIPTION
These are used inconsistently throughout the document, even in the same
paragraph. Prefer the \verb"" form as it gives more semantic context for
post-processors (e.g. pandoc).