### PR TITLE
Make "keys" in glossaries bold consistently

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2096,60 +2096,60 @@ compare to the difference in pregnancy length?
 
 \begin{itemize}
 
-\item distribution: The values that appear in a sample
+\item {\bf distribution}: The values that appear in a sample
 and the frequency of each.
 \index{distribution}
 
-\item histogram: A mapping from values to frequencies, or a graph
+\item {\bf histogram}: A mapping from values to frequencies, or a graph
 that shows this mapping.
 \index{histogram}
 
-\item frequency: The number of times a value appears in a sample.
+\item {\bf frequency}: The number of times a value appears in a sample.
 \index{frequency}
 
-\item mode: The most frequent value in a sample, or one of the
+\item {\bf mode}: The most frequent value in a sample, or one of the
 most frequent values.
 \index{mode}
 
-\item normal distribution: An idealization of a bell-shaped distribution;
+\item {\bf normal distribution}: An idealization of a bell-shaped distribution;
 also known as a Gaussian distribution. 
 \index{Gaussian distribution}
 \index{normal distribution}
 
-\item uniform distribution: A distribution in which all values have
+\item {\bf uniform distribution}: A distribution in which all values have
 the same frequency.
 \index{uniform distribution}
 
-\item tail: The part of a distribution at the high and low extremes.
+\item {\bf tail}: The part of a distribution at the high and low extremes.
 \index{tail}
 
-\item central tendency: A characteristic of a sample or population;
+\item {\bf central tendency}: A characteristic of a sample or population;
 intuitively, it is an average or typical value. 
 \index{central tendency}
 
-\item outlier: A value far from the central tendency.
+\item {\bf outlier}: A value far from the central tendency.
 \index{outlier}
 
-\item spread: A measure of how spread out the values in a distribution
+\item {\bf spread}: A measure of how spread out the values in a distribution
 are.
 \index{spread}
 
-\item summary statistic: A statistic that quantifies some aspect
+\item {\bf summary statistic}: A statistic that quantifies some aspect
 of a distribution, like central tendency or spread.
 \index{summary statistic}
 
-\item variance: A summary statistic often used to quantify spread.
+\item {\bf variance}: A summary statistic often used to quantify spread.
 \index{variance}
 
-\item standard deviation: The square root of variance, also used
+\item {\bf standard deviation}: The square root of variance, also used
 as a measure of spread.
 \index{standard deviation}
 
-\item effect size: A summary statistic intended to quantify the size
+\item {\bf effect size}: A summary statistic intended to quantify the size
 of an effect like a difference between groups.
 \index{effect size}
 
-\item clinically significant: A result, like a difference between groups,
+\item {\bf clinically significant}: A result, like a difference between groups,
 that is relevant in practice.
 \index{clinically significant}
 
@@ -2775,21 +2775,21 @@ exercise is in \verb"relay_soln.py".
 
 \begin{itemize}
 
-\item Probability mass function (PMF): a representation of a distribution
+\item {\bf Probability mass function (PMF)}: a representation of a distribution
 as a function that maps from values to probabilities.
 \index{PMF}
 \index{probability mass function}
 
-\item probability: A frequency expressed as a fraction of the sample
+\item {\bf probability}: A frequency expressed as a fraction of the sample
 size.
 \index{frequency}
 \index{probability}
 
-\item normalization: The process of dividing a frequency by a sample
+\item {\bf normalization}: The process of dividing a frequency by a sample
 size to get a probability.
 \index{normalization}
 
-\item index: In a pandas DataFrame, the index is a special column
+\item {\bf index}: In a pandas DataFrame, the index is a special column
 that contains the row labels.
 \index{pandas}
 \index{DataFrame}
@@ -3312,36 +3312,36 @@ PMF and CDF.  Is the distribution uniform?
 
 \begin{itemize}
 
-\item percentile rank: The percentage of values in a distribution that are
+\item {\bf percentile rank}: The percentage of values in a distribution that are
 less than or equal to a given value.
 \index{percentile rank}
 
-\item percentile: The value associated with a given percentile rank.
+\item {\bf percentile}: The value associated with a given percentile rank.
 \index{percentile}
 
-\item cumulative distribution function (CDF): A function that maps
+\item {\bf cumulative distribution function (CDF)}: A function that maps
   from values to their cumulative probabilities.  $\CDF(x)$ is the
   fraction of the sample less than or equal to $x$.  \index{CDF}
 \index{cumulative probability}
 
-\item inverse CDF: A function that maps from a cumulative probability,
+\item {\bf inverse CDF}: A function that maps from a cumulative probability,
   $p$, to the corresponding value.
 \index{inverse CDF}
 \index{CDF, inverse}
 
-\item median: The 50th percentile, often used as a measure of central
+\item {\bf median}: The 50th percentile, often used as a measure of central
   tendency.  \index{median}
 
-\item interquartile range: The difference between
+\item {\bf interquartile range}: The difference between
 the 75th and 25th percentiles, used as a measure of spread.
 \index{interquartile range}
 
-\item quantile: A sequence of values that correspond to equally spaced
+\item {\bf quantile}: A sequence of values that correspond to equally spaced
 percentile ranks; for example, the quartiles of a distribution are
 the 25th, 50th and 75th percentiles.
 \index{quantile}
 
-\item replacement: A property of a sampling process. ``With replacement''
+\item {\bf replacement}: A property of a sampling process. ``With replacement''
 means that the same value can be chosen more than once; ``without
 replacement'' means that once a value is chosen, it is removed from
 the population.
@@ -4158,30 +4158,30 @@ solution to this exercise is in \url{hinc_soln.py}.
 
 \begin{itemize}
 
-\item empirical distribution: The distribution of values in a sample.
+\item {\bf empirical distribution}: The distribution of values in a sample.
   \index{empirical distribution} \index{distribution!empirical}
 
-\item analytic distribution: A distribution whose CDF is an analytic
+\item {\bf analytic distribution}: A distribution whose CDF is an analytic
 function.
 \index{analytic distribution}
 \index{distribution!analytic}
 
-\item model: A useful simplification.  Analytic distributions are
+\item {\bf model}: A useful simplification.  Analytic distributions are
 often good models of more complex empirical distributions.
 \index{model}
 
-\item interarrival time: The elapsed time between two events.
+\item {\bf interarrival time}: The elapsed time between two events.
 \index{interarrival time}
 
-\item complementary CDF: A function that maps from a value, $x$,
+\item {\bf complementary CDF}: A function that maps from a value, $x$,
 to the fraction of values that exceed $x$, which is $1 - \CDF(x)$.
 \index{complementary CDF} \index{CDF!complementary} \index{CCDF}
 
-\item standard normal distribution: The normal distribution with
+\item {\bf standard normal distribution}: The normal distribution with
 mean 0 and standard deviation 1.
 \index{standard normal distribution}
 
-\item normal probability plot: A plot of the values in a sample versus
+\item {\bf normal probability plot}: A plot of the values in a sample versus
 random values from a standard normal distribution.
 \index{normal probability plot}
 \index{plot!normal probability}
@@ -4932,49 +4932,49 @@ upper bound?
 
 \begin{itemize}
 
-\item Probability density function (PDF): The derivative of a continuous CDF,
+\item {\bf Probability density function (PDF)}: The derivative of a continuous CDF,
 a function that maps a value to its probability density.
 \index{PDF}
 \index{probability density function}
 
-\item Probability density: A quantity that can be integrated over a
+\item {\bf Probability density}: A quantity that can be integrated over a
   range of values to yield a probability.  If the values are in units
   of cm, for example, probability density is in units of probability
   per cm.
 \index{probability density}
 
-\item Kernel density estimation (KDE): An algorithm that estimates a PDF
+\item {\bf Kernel density estimation (KDE)}: An algorithm that estimates a PDF
 based on a sample.
 \index{kernel density estimation}
 \index{KDE}
 
-\item discretize: To approximate a continuous function or distribution
+\item {\bf discretize}: To approximate a continuous function or distribution
 with a discrete function.  The opposite of smoothing.
 \index{discretize}
 
-\item raw moment: A statistic based on the sum of data raised to a power.
+\item {\bf raw moment}: A statistic based on the sum of data raised to a power.
 \index{raw moment}
 
-\item central moment: A statistic based on deviation from the mean,
+\item {\bf central moment}: A statistic based on deviation from the mean,
 raised to a power.
 \index{central moment}
 
-\item standardized moment: A ratio of moments that has no units.
+\item {\bf standardized moment}: A ratio of moments that has no units.
 \index{standardized moment}
 
-\item skewness: A measure of how asymmetric a distribution is.
+\item {\bf skewness}: A measure of how asymmetric a distribution is.
 \index{skewness}
 
-\item sample skewness: A moment-based statistic intended to quantify
+\item {\bf sample skewness}: A moment-based statistic intended to quantify
 the skewness of a distribution.
 \index{sample skewness}
 
-\item Pearson's median skewness coefficient: A statistic intended to
+\item {\bf Pearson's median skewness coefficient}: A statistic intended to
   quantify the skewness of a distribution based on the median, mean,
   and standard deviation.
   \index{Pearson median skewness}
 
-\item robust: A statistic is robust if it is relatively immune to the
+\item {\bf robust}: A statistic is robust if it is relatively immune to the
   effect of outliers.
 \index{robust}
 
@@ -5650,52 +5650,52 @@ between these variables?
 
 \begin{itemize}
 
-\item scatter plot: A visualization of the relationship between
+\item {\bf scatter plot}: A visualization of the relationship between
 two variables, showing one point for each row of data.
 \index{scatter plot}
 
-\item jitter: Random noise added to data for purposes of
+\item {\bf jitter}: Random noise added to data for purposes of
 visualization.
 \index{jitter}
 
-\item saturation: Loss of information when multiple points are
+\item {\bf saturation}: Loss of information when multiple points are
 plotted on top of each other. 
 \index{saturation}
 
-\item correlation: A statistic that measures the strength of the
+\item {\bf correlation}: A statistic that measures the strength of the
 relationship between two variables.
 \index{correlation}
 
-\item standardize: To transform a set of values so that their mean is 0 and
+\item {\bf standardize}: To transform a set of values so that their mean is 0 and
 their variance is 1.
 \index{standardize}
 
-\item standard score: A value that has been standardized so that it is
+\item {\bf standard score}: A value that has been standardized so that it is
   expressed in standard deviations from the mean.
   \index{standard score}
 \index{standard deviation}
 
-\item covariance: A measure of the tendency of two variables
+\item {\bf covariance}: A measure of the tendency of two variables
 to vary together.
 \index{covariance}
 
-\item rank: The index where an element appears in a sorted list.
+\item {\bf rank}: The index where an element appears in a sorted list.
 \index{rank}
 
-\item randomized controlled trial: An experimental design in which subjects
+\item {\bf randomized controlled trial}: An experimental design in which subjects
 are divided into groups at random, and different groups are given different
 treatments.
 \index{randomized controlled trial}
 
-\item treatment group: A group in a controlled trial that receives
+\item {\bf treatment group}: A group in a controlled trial that receives
 some kind of intervention.
 \index{treatment group}
 
-\item control group: A group in a controlled trial that receives no
+\item {\bf control group}: A group in a controlled trial that receives no
 treatment, or a treatment whose effect is known.
 \index{control group}
 
-\item natural experiment: An experimental design that takes advantage of
+\item {\bf natural experiment}: An experimental design that takes advantage of
 a natural division of subjects into groups in ways that are at least
 approximately random.
 \index{natural experiment}
@@ -6324,49 +6324,49 @@ values of {\tt lam}?
 
 \begin{itemize}
 
-\item estimation: The process of inferring the parameters of a distribution
+\item {\bf estimation}: The process of inferring the parameters of a distribution
 from a sample.
 \index{estimation}
 
-\item estimator: A statistic used to estimate a parameter.
+\item {\bf estimator}: A statistic used to estimate a parameter.
 \index{estimation}
 
-\item mean squared error (MSE): A measure of estimation error.
+\item {\bf mean squared error (MSE)}: A measure of estimation error.
 \index{mean squared error}
 \index{MSE}
 
-\item root mean squared error (RMSE): The square root of MSE,
+\item {\bf root mean squared error (RMSE)}: The square root of MSE,
 a more meaningful representation of typical error magnitude.
 \index{mean squared error}
 \index{MSE}
 
-\item maximum likelihood estimator (MLE): An estimator that computes the
+\item {\bf maximum likelihood estimator (MLE)}: An estimator that computes the
 point estimate most likely to be correct.
 \index{MLE}
 \index{maximum likelihood estimator}
 
-\item bias (of an estimator): The tendency of an estimator to be above or
+\item {\bf bias (of an estimator)}: The tendency of an estimator to be above or
   below the actual value of the parameter, when averaged over repeated
   experiments.  \index{biased estimator}
 
-\item sampling error: Error in an estimate due to the limited
+\item {\bf sampling error}: Error in an estimate due to the limited
   size of the sample and variation due to chance. \index{point estimation}
 
-\item sampling bias: Error in an estimate due to a sampling process
+\item {\bf sampling bias}: Error in an estimate due to a sampling process
   that is not representative of the population. \index{sampling bias}
 
-\item measurement error: Error in an estimate due to inaccuracy collecting
+\item {\bf measurement error}: Error in an estimate due to inaccuracy collecting
   or recording data. \index{measurement error}
 
-\item sampling distribution: The distribution of a statistic if an
+\item {\bf sampling distribution}: The distribution of a statistic if an
   experiment is repeated many times.  \index{sampling distribution}
 
-\item standard error: The RMSE of an estimate,
+\item {\bf standard error}: The RMSE of an estimate,
 which quantifies variability due to sampling error (but not
 other sources of error).
 \index{standard error}
 
-\item confidence interval: An interval that represents the expected
+\item {\bf confidence interval}: An interval that represents the expected
   range of an estimator if an experiment is repeated many times.
   \index{confidence interval} \index{interval!confidence}
 
@@ -7336,55 +7336,55 @@ birth weight.  How much does the model affect the results?
 
 \begin{itemize}
 
-\item hypothesis testing: The process of determining whether an apparent
+\item {\bf hypothesis testing}: The process of determining whether an apparent
 effect is statistically significant.
 \index{hypothesis testing}
 
-\item test statistic: A statistic used to quantify an effect size.
+\item {\bf test statistic}: A statistic used to quantify an effect size.
 \index{test statistic}
 \index{effect size}
 
-\item null hypothesis: A model of a system based on the assumption that
+\item {\bf null hypothesis}: A model of a system based on the assumption that
 an apparent effect is due to chance.
 \index{null hypothesis}
 
-\item p-value: The probability that an effect could occur by chance.
+\item {\bf p-value}: The probability that an effect could occur by chance.
 \index{p-value}
 
-\item statistically significant: An effect is statistically
+\item {\bf statistically significant}: An effect is statistically
   significant if it is unlikely to occur by chance.
   \index{significant} \index{statistically significant}
 
-\item permutation test: A way to compute p-values by generating
+\item {\bf permutation test}: A way to compute p-values by generating
   permutations of an observed dataset.
   \index{permutation test}
 
-\item resampling test: A way to compute p-values by generating
+\item {\bf resampling test}: A way to compute p-values by generating
   samples, with replacement, from an observed dataset.
   \index{resampling test}
 
-\item two-sided test: A test that asks, ``What is the chance of an effect
+\item {\bf two-sided test}: A test that asks, ``What is the chance of an effect
 as big as the observed effect, positive or negative?''
 
-\item one-sided test: A test that asks, ``What is the chance of an effect
+\item {\bf one-sided test}: A test that asks, ``What is the chance of an effect
 as big as the observed effect, and with the same sign?''
 \index{one-sided test}
 \index{two-sided test}
 \index{test!one-sided}
 \index{test!two-sided}
 
-\item chi-squared test: A test that uses the chi-squared statistic as
+\item {\bf chi-squared test}: A test that uses the chi-squared statistic as
 the test statistic.
 \index{chi-squared test}
 
-\item false positive: The conclusion that an effect is real when it is not.
+\item {\bf false positive}: The conclusion that an effect is real when it is not.
 \index{false positive}
 
-\item false negative: The conclusion that an effect is due to chance when it
+\item {\bf false negative}: The conclusion that an effect is due to chance when it
 is not.
 \index{false negative}
 
-\item power: The probability of a positive test if the null hypothesis
+\item {\bf power}: The probability of a positive test if the null hypothesis
 is false.
 \index{power}
 \index{null hypothesis}
@@ -8140,24 +8140,24 @@ estimates?
 
 \begin{itemize}
 
-\item linear fit: a line intended to model the relationship between
+\item {\bf linear fit}: a line intended to model the relationship between
 variables.  \index{linear fit}
 
-\item least squares fit: A model of a dataset that minimizes the
+\item {\bf least squares fit}: A model of a dataset that minimizes the
 sum of squares of the residuals.
 \index{least squares fit}
 
-\item residual: The deviation of an actual value from a model.
+\item {\bf residual}: The deviation of an actual value from a model.
 \index{residuals}
 
-\item goodness of fit: A measure of how well a model fits data.
+\item {\bf goodness of fit}: A measure of how well a model fits data.
 \index{goodness of fit}
 
-\item coefficient of determination: A statistic intended to
+\item {\bf coefficient of determination}: A statistic intended to
 quantify goodness of fit.
 \index{coefficient of determination}
 
-\item sampling weight: A value associated with an observation in a
+\item {\bf sampling weight}: A value associated with an observation in a
   sample that indicates what part of the population it represents.
 \index{sampling weight}
 
@@ -9284,72 +9284,72 @@ What is the probability that she is married, cohabitating, etc?
 
 \begin{itemize}
 
-\item regression: One of several related processes for estimating parameters
+\item {\bf regression}: One of several related processes for estimating parameters
 that fit a model to data.
 \index{regression}
 
-\item dependent variables: The variables in a regression model we would
+\item {\bf dependent variables}: The variables in a regression model we would
 like to predict.  Also known as endogenous variables.
 \index{dependent variable}
 \index{endogenous variable}
 
-\item explanatory variables: The variables used to predict or explain
+\item {\bf explanatory variables}: The variables used to predict or explain
 the dependent variables.  Also known as independent, or exogenous,
 variables.
 \index{explanatory variable}
 \index{exogenous variable}
 
-\item simple regression: A regression with only one dependent and
+\item {\bf simple regression}: A regression with only one dependent and
 one explanatory variable.
 \index{simple regression}
 
-\item multiple regression: A regression with multiple explanatory
+\item {\bf multiple regression}: A regression with multiple explanatory
 variables, but only one dependent variable.
 \index{multiple regression}
 
-\item linear regression: A regression based on a linear model.
+\item {\bf linear regression}: A regression based on a linear model.
 \index{linear regression}
 
-\item ordinary least squares: A linear regression that estimates
+\item {\bf ordinary least squares}: A linear regression that estimates
 parameters by minimizing the squared error of the residuals.
 \index{ordinary least squares}
 
-\item spurious relationship: A relationship between two variables that is 
+\item {\bf spurious relationship}: A relationship between two variables that is 
 caused by a statistical artifact or a factor, not included in the
 model, that is related to both variables.
 \index{spurious relationship}
 
-\item control variable: A variable included in a regression to
+\item {\bf control variable}: A variable included in a regression to
 eliminate or ``control for'' a spurious relationship.
 \index{control variable}
 
-\item proxy variable: A variable that contributes information to
+\item {\bf proxy variable}: A variable that contributes information to
 a regression model indirectly because of a relationship with another
 factor, so it acts as a proxy for that factor.
 \index{proxy variable}
 
-\item categorical variable: A variable that can have one of a
+\item {\bf categorical variable}: A variable that can have one of a
 discrete set of unordered values.
 \index{categorical variable}
 
-\item join: An operation that combines data from two DataFrames
+\item {\bf join}: An operation that combines data from two DataFrames
 using a key to match up rows in the two frames.
 \index{join}
 \index{DataFrame}
 
-\item data mining: An approach to finding relationships between
+\item {\bf data mining}: An approach to finding relationships between
 variables by testing a large number of models.
 \index{data mining}
 
-\item logistic regression: A form of regression used when the
+\item {\bf logistic regression}: A form of regression used when the
 dependent variable is boolean.
 \index{logistic regression}
 
-\item Poisson regression: A form of regression used when the
+\item {\bf Poisson regression}: A form of regression used when the
 dependent variable is a non-negative integer, usually a count.
 \index{Poisson regression}
 
-\item odds: An alternative way of representing a probability, $p$, as
+\item {\bf odds}: An alternative way of representing a probability, $p$, as
   the ratio of the probability and its complement, $p / (1-p)$.
 \index{odds}
 
@@ -10412,49 +10412,49 @@ elements.
 
 \begin{itemize}
 
-\item time series: A dataset where each value is associated with
+\item {\bf time series}: A dataset where each value is associated with
 a timestamp, often a series of measurements and the times they
 were collected.
 \index{time series}
 
-\item window: A sequence of consecutive values in a time series,
+\item {\bf window}: A sequence of consecutive values in a time series,
 often used to compute a moving average.
 \index{window}
 
-\item moving average: One of several statistics intended to estimate
+\item {\bf moving average}: One of several statistics intended to estimate
 the underlying trend in a time series by computing averages (of
 some kind) for a series of overlapping windows.
 \index{moving average}
 
-\item rolling mean: A moving average based on the mean value in
+\item {\bf rolling mean}: A moving average based on the mean value in
 each window.
 \index{rolling mean}
 
-\item exponentially-weighted moving average (EWMA): A moving
+\item {\bf exponentially-weighted moving average (EWMA)}: A moving
 average based on a weighted mean that gives the highest weight
 to the most recent values, and exponentially decreasing weights
 to earlier values. \index{exponentially-weighted moving average} \index{EWMA}
 
-\item span: A parameter of EWMA that determines how quickly the
+\item {\bf span}: A parameter of EWMA that determines how quickly the
 weights decrease.
 \index{span}
 
-\item serial correlation: Correlation between a time series and
+\item {\bf serial correlation}: Correlation between a time series and
 a shifted or lagged version of itself.
 \index{serial correlation}
 
-\item lag: The size of the shift in a serial correlation or
+\item {\bf lag}: The size of the shift in a serial correlation or
 autocorrelation.
 \index{lag}
 
-\item autocorrelation: A more general term for a serial correlation
+\item {\bf autocorrelation}: A more general term for a serial correlation
 with any amount of lag.
 \index{autocorrelation function}
 
-\item autocorrelation function: A function that maps from lag to
+\item {\bf autocorrelation function}: A function that maps from lag to
 serial correlation.
 
-\item stationary: A model is stationary if the parameters and the
+\item {\bf stationary}: A model is stationary if the parameters and the
 distribution of residuals does not change over time.
 \index{model}
 \index{stationary model}
@@ -11428,34 +11428,34 @@ and possibly by age at first marriage.
 
 \begin{itemize}
 
-\item survival analysis: A set of methods for describing and
+\item {\bf survival analysis}: A set of methods for describing and
   predicting lifetimes, or more generally time until an event occurs.
 \index{survival analysis}
 
-\item survival curve: A function that maps from a time, $t$, to the
+\item {\bf survival curve}: A function that maps from a time, $t$, to the
   probability of surviving past $t$.
 \index{survival curve}
 
-\item hazard function: A function that maps from $t$ to the fraction
+\item {\bf hazard function}: A function that maps from $t$ to the fraction
 of people alive until $t$ who die at $t$.
 \index{hazard function}
 
-\item Kaplan-Meier estimation: An algorithm for estimating hazard and
+\item {\bf Kaplan-Meier estimation}: An algorithm for estimating hazard and
 survival functions.
 \index{Kaplan-Meier estimation}
 
-\item cohort: a group of subjects defined by an event, like date of
+\item {\bf cohort}: a group of subjects defined by an event, like date of
 birth, in a particular interval of time.
 \index{cohort}
 
-\item cohort effect: a difference between cohorts.
+\item {\bf cohort effect}: a difference between cohorts.
 \index{cohort effect}
 
-\item NBUE: A property of expected remaining lifetime, ``New
+\item {\bf NBUE}: A property of expected remaining lifetime, ``New
 better than used in expectation.''
 \index{NBUE}
 
-\item UBNE: A property of expected remaining lifetime, ``Used
+\item {\bf UBNE}: A property of expected remaining lifetime, ``Used
 better than new in expectation.''
 \index{UBNE}
 


### PR DESCRIPTION
The keys for the first chapter glossary are bold, but later glossaries
are not. Make them all bold to be consistent. (The bold version looks
better IMHO).