### PR TITLE
Fix missing \tt format for filename `nsfg.py`

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -507,8 +507,8 @@ that include these packages.
 \index{installation}
 
 After you clone the repository or unzip the zip file, you should have
-a folder called {\tt ThinkStats2/code} with a file called {nsfg.py}.
-If you run {nsfg.py}, it should read a data file, run some tests, and print a
+a folder called {\tt ThinkStats2/code} with a file called {\tt nsfg.py}.
+If you run {\tt nsfg.py}, it should read a data file, run some tests, and print a
 message like, ``All tests passed.''  If you get import errors, it
 probably means there are packages you need to install.
 


### PR DESCRIPTION
This was missing in one early paragraph. Elswhere it is formated with
\tt.