### PR TITLE
Display `hinc_soln.py` as \tt not \url

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -4146,7 +4146,7 @@ will also find {\tt hinc.py}, which reads this file.
 
 Extract the distribution of incomes from this dataset.  Are any of the
 analytic distributions in this chapter a good model of the data?  A
-solution to this exercise is in \url{hinc_soln.py}.
+solution to this exercise is in {\tt hinc_soln.py}.
 \index{model}
 
 \end{exercise}


### PR DESCRIPTION
One occurance of this. Fix to make consistent.