### PR TITLE
Update book.tex

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -567,7 +567,7 @@ corrections and suggestions.
 \item Andy Pethan and Molly Farison helped debug some of the solutions,
 and Molly spotted several typos.
 
-\item Dr. Nikolas Akerblom knows how big a Hyracotherium is.
+\item Dr.\ Nikolas Akerblom knows how big a Hyracotherium is.
 
 \item Alex Morrow clarified one of the code examples.
 


### PR DESCRIPTION
The "\ " puts a smaller space than the M-space that occurs at the end of sentences. See: https://tex.stackexchange.com/questions/2229/is-a-period-after-an-abbreviation-the-same-as-an-end-of-sentence-period