### PR TITLE
#179 Fix - deprecated type passed to `np.linspace`

### DIFF
--- a/code/chap06ex.ipynb
+++ b/code/chap06ex.ipynb
@@ -770,7 +770,7 @@
     "    # each range\n",
     "    arrays = []\n",
     "    for _, row in df.iterrows():\n",
-    "        vals = np.linspace(row.log_lower, row.log_upper, row.freq)\n",
+    "        vals = np.linspace(row.log_lower, row.log_upper, int(row.freq))\n",
     "        arrays.append(vals)\n",
     "\n",
     "    # collect the arrays into a single sample\n",


### PR DESCRIPTION
Original notebook throws the following warning from `InterpolateSample`:

```
/home/downey/anaconda3/envs/ModSimPy/lib/python3.6/site-packages/ipykernel_launcher.py:26: DeprecationWarning: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
```

Looks like this is fully deprecated in new versions, breaking the notebook. Casting `row.freq` to an `int` fixes the issue. Cells afterward then work as intended.

Should `row.freq` be rounded instead of truncated? I don't think so but I leave that decision to the experts.