### PR TITLE
Updating code location for chapter 8's exercises

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -6248,8 +6248,8 @@ estimator of $\lambda$.
 
 \section{Exercises}
 
-For the following exercises, you might want to start with a copy of
-\verb"estimation.py".  Solutions are in \verb"chap08soln.py"
+For the following exercises, you can find starter code in
+\verb"chap08ex.ipynb".  Solutions are in \verb"chap08soln.py"
 
 \begin{exercise}
 


### PR DESCRIPTION
The book recommends you make a copy of `estimation.py` to complete the chapter 8 exercises.

While we could do this, the other chapters thus far point to a Jupyter notebook for end of chapter exercises.

Since there is a Jupyter notebook for chapter 8: `chap08ex.ipynb`, I suggest we refer readers to that notebook instead of `estimation.py`. The end of chapter exercises in the book chapter are the same as those in the chapter 8 notebook.