### PR TITLE
Fixed codebook URL (chap02ex.ipynb)

### DIFF
--- a/code/chap02ex.ipynb
+++ b/code/chap02ex.ipynb
@@ -599,7 +599,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make a histogram of <tt>totincr</tt> the total income for the respondent's family.  To interpret the codes see the [codebook](ftp://ftp.cdc.gov/pub/Health_Statistics/NCHS/Dataset_Documentation/NSFG/Cycle6Codebook-Pregnancy.pdf)."
+    "Make a histogram of <tt>totincr</tt> the total income for the respondent's family.  To interpret the codes see the [codebook](ftp://ftp.cdc.gov/pub/Health_Statistics/NCHS/Dataset_Documentation/NSFG/Cycle6Codebook-Female.pdf)."
    ]
   },
   {


### PR DESCRIPTION
The codebook URL at a cell in `chap02ex.ipynb` states [Cycle6Codebook-Pregnancy.pdf](ftp://ftp.cdc.gov/pub/Health_Statistics/NCHS/Dataset_Documentation/NSFG/Cycle6Codebook-Pregnancy.pdf) for code references, though it seems that it should be [Cycle6Codebook-Female.pdf](ftp://ftp.cdc.gov/pub/Health_Statistics/NCHS/Dataset_Documentation/NSFG/Cycle6Codebook-Female.pdf) instead.

The correct codes from that cell on (`totincr`, `numfmhh`, `parity`, `age_r`) all seem related to the **female** codebook.