### PR TITLE
Update nsfg.py to fix FutureWarning

### DIFF
--- a/code/nsfg.py
+++ b/code/nsfg.py
@@ -65,12 +65,17 @@ def CleanFemPreg(df):
     
     # replace 'not ascertained', 'refused', 'don't know' with NaN
     na_vals = [97, 98, 99]
-    df.birthwgt_lb.replace(na_vals, np.nan, inplace=True)
-    df.birthwgt_oz.replace(na_vals, np.nan, inplace=True)
-    df.hpagelb.replace(na_vals, np.nan, inplace=True)
-
-    df.babysex.replace([7, 9], np.nan, inplace=True)
-    df.nbrnaliv.replace([9], np.nan, inplace=True)
+    df.replace(
+        to_replace={
+            "birthwgt_lb": na_vals,
+            "birthwgt_oz": na_vals,
+            "hpagelb": na_vals,
+            "babysex": [7, 9],
+            "nbrnaliv": [9],
+        },
+        value=np.nan,
+        inplace=True,
+    )
 
     # birthweight is stored in two columns, lbs and oz.
     # convert to a single column in lb


### PR DESCRIPTION
Fix warning:

```
ThinkStats2/code/nsfg.py:66: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method. The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.
```